### PR TITLE
Planetary Dominion: mobile-first tile-map colony game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# codex-playground
-Playground for codex
+# Planetary Dominion
+
+Mobile-first 2D tile-map colony/resource game built with vanilla HTML/CSS/JS modules.
+
+## Run locally
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open: `http://localhost:8000`
+
+## Controls
+
+- **Touch**: one-finger pan, two-finger pinch zoom, tap to place in placement mode.
+- **Desktop**: mouse drag pan, wheel zoom, WASD/arrow pan.
+
+## Gameplay loop
+
+1. Start on **Terra Nova**.
+2. Place extractors on resource nodes, and support buildings on empty tiles.
+3. Upgrade buildings (L1-L10).
+4. Buy tech ranks in Tech tab.
+5. Unlock additional planets via Planet tab milestones.
+
+## Features implemented
+
+- 4 deterministic planets with unique resource nodes and palettes.
+- Building placement rules and per-planet constraints.
+- Formula-driven economy (cost growth, production scaling, storage caps).
+- Offline progress (capped at 12 hours).
+- Autosave every 10s + visibility/pagehide save.
+- Save export/import/reset.
+- iPhone-safe layout with viewport-fit, safe-area insets, and 44px touch targets.
+- Canvas map rendering + DOM overlay UI.
+- Reduced motion toggle + prefers-reduced-motion default.
+
+## Quick test checklist
+
+1. Place extractor on node (works) and empty tile (rejected).
+2. Place power/lab/storage on empty tile only; only one each per planet.
+3. Upgrade and verify production and caps rise.
+4. Buy tech and verify costs scale and production improves.
+5. Unlock Ignis/Aqua/Zephyria via requirements.
+6. Refresh page and confirm save/load.
+7. Modify `lastSeen` in localStorage to verify offline progress.
+
+## Deploy
+
+Deploy as static files (GitHub Pages, Netlify static, Vercel static). No build step required.

--- a/index.html
+++ b/index.html
@@ -1,48 +1,75 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Codex Playground</title>
-  <style>
-    body { font-family: Arial, sans-serif; }
-    .tabs { display: flex; }
-    .tab { padding: 10px 20px; cursor: pointer; border: 1px solid #ccc; border-bottom: none; }
-    .tab.active { background-color: #f0f0f0; }
-    .tab-content { border: 1px solid #ccc; padding: 20px; }
-    .tab-content > div { display: none; }
-    .tab-content > div.active { display: block; }
-  </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Planetary Dominion</title>
+  <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
-  <div class="tabs">
-    <div class="tab active" data-target="home">Home</div>
-    <div class="tab" data-target="profile">My Profile</div>
-  </div>
-  <div class="tab-content">
-    <div id="home" class="active">
-      <h2>Welcome to the Codex Playground</h2>
-      <p>This is the home tab.</p>
+  <div id="app">
+    <div id="canvasWrap"><canvas id="gameCanvas"></canvas></div>
+    <div id="overlay">
+      <div id="resourceBar"></div>
+      <section id="panel"></section>
+      <nav id="tabs">
+        <button data-tab="planet" class="active">Planet</button>
+        <button data-tab="build">Build</button>
+        <button data-tab="tech">Tech</button>
+        <button data-tab="settings">Settings</button>
+      </nav>
     </div>
-    <div id="profile">
-      <h2>My Profile</h2>
-      <p>Profile details go here.</p>
-    </div>
   </div>
 
-  <script>
-    const tabs = document.querySelectorAll('.tab');
-    const contents = document.querySelectorAll('.tab-content > div');
+  <script type="module">
+    import { loadGame, saveGame } from "./modules/save.js";
+    import { applyOfflineProgress, tick, recalcCaps } from "./modules/sim.js";
+    import { Renderer } from "./modules/renderer.js";
+    import { attachInput } from "./modules/input.js";
+    import { setupUI } from "./modules/ui.js";
 
-    tabs.forEach(tab => {
-      tab.addEventListener('click', () => {
-        tabs.forEach(t => t.classList.remove('active'));
-        contents.forEach(c => c.classList.remove('active'));
+    const state = loadGame();
+    applyOfflineProgress(state);
+    recalcCaps(state);
 
-        tab.classList.add('active');
-        const target = document.getElementById(tab.dataset.target);
-        target.classList.add('active');
-      });
+    if (state.settings.reducedMotion) document.body.classList.add("reduce-motion");
+
+    const canvas = document.getElementById("gameCanvas");
+    const renderer = new Renderer(canvas, state);
+    const ui = setupUI(state, onStateChanged);
+
+    function onStateChanged() {
+      recalcCaps(state);
+      ui.render();
+    }
+
+    attachInput(canvas, state, renderer, onStateChanged);
+    window.addEventListener("resize", () => renderer.resize());
+    ui.render();
+
+    let acc = 0;
+    let last = performance.now();
+    function frame(now) {
+      const dt = (now - last) / 1000;
+      last = now;
+      acc += dt;
+      const fixed = 0.2;
+      while (acc >= fixed) {
+        tick(state, fixed);
+        acc -= fixed;
+      }
+      renderer.draw();
+      if (!state.settings.reducedMotion || now % 200 < 16) ui.render();
+      requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+
+    setInterval(() => saveGame(state), 10000);
+    const saveNow = () => saveGame(state);
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) saveNow();
     });
+    window.addEventListener("pagehide", saveNow);
   </script>
 </body>
 </html>

--- a/modules/balance.js
+++ b/modules/balance.js
@@ -1,0 +1,237 @@
+import { clamp } from "./utils.js";
+
+export const resourceWeights = {
+  minerals: 1,
+  energy: 3,
+  biomass: 4,
+  rareGas: 10,
+};
+
+export const planets = [
+  {
+    id: "terra",
+    name: "Terra Nova",
+    resource: "minerals",
+    baseRate: 1.2,
+    yieldMult: 1,
+    costMult: 1,
+    accent: "#2cc4d7",
+    bg: "#122649",
+  },
+  {
+    id: "ignis",
+    name: "Ignis Prime",
+    resource: "energy",
+    baseRate: 0.8,
+    yieldMult: 1.15,
+    costMult: 1.15,
+    accent: "#df7b37",
+    bg: "#2a1835",
+  },
+  {
+    id: "aqua",
+    name: "Aqua Minor",
+    resource: "biomass",
+    baseRate: 0.9,
+    yieldMult: 1.1,
+    costMult: 1.1,
+    accent: "#43d7b2",
+    bg: "#0f2840",
+  },
+  {
+    id: "zephyria",
+    name: "Zephyria",
+    resource: "rareGas",
+    baseRate: 0.35,
+    yieldMult: 1.25,
+    costMult: 1.35,
+    accent: "#6f8dff",
+    bg: "#151f53",
+  },
+];
+
+export const BUILDING_TYPES = ["extractor", "power", "lab", "storage"];
+
+export const constants = {
+  alpha: 1.1,
+  powerPmax: 0.55,
+  powerDecay: 0.88,
+  baseCap: 1000,
+  capGain: 0.35,
+  capExp: 0.85,
+  buildGrowth: 1.55,
+  extractorUpgradeGrowth: 1.28,
+  powerGrowth: 1.25,
+  labGrowth: 1.27,
+  storageGrowth: 1.22,
+  techGrowth: 1.35,
+  techDiscountMax: 0.18,
+  techDiscountDecay: 0.85,
+};
+
+const baseBuild = {
+  terra: { minerals: 150 },
+  ignis: { minerals: 220, energy: 80 },
+  aqua: { minerals: 240, energy: 120 },
+  zephyria: { minerals: 300, energy: 180, biomass: 80 },
+};
+
+const baseUpgradeExtractor = {
+  terra: { minerals: 40 },
+  ignis: { minerals: 55, energy: 25 },
+  aqua: { minerals: 60, biomass: 25 },
+  zephyria: { minerals: 70, rareGas: 18 },
+};
+
+const basePower = {
+  terra: { minerals: 120 },
+  ignis: { minerals: 120, energy: 40 },
+  aqua: { minerals: 120, energy: 40 },
+  zephyria: { minerals: 140, energy: 55, rareGas: 15 },
+};
+
+const baseLab = {
+  terra: { minerals: 160 },
+  ignis: { minerals: 160, energy: 60 },
+  aqua: { minerals: 160, biomass: 60 },
+  zephyria: { minerals: 180, biomass: 80, rareGas: 20 },
+};
+
+const baseStorage = {
+  terra: { minerals: 80 },
+  ignis: { minerals: 90, energy: 30 },
+  aqua: { minerals: 90, biomass: 30 },
+  zephyria: { minerals: 110, rareGas: 25 },
+};
+
+export const techDefs = {
+  extraction: {
+    label: "Extraction Efficiency",
+    maxBonus: 1,
+    decay: 0.85,
+    baseCost: { minerals: 90 },
+  },
+  energyOpt: {
+    label: "Energy Optimization",
+    baseCost: { minerals: 120, energy: 45 },
+  },
+  logistics: {
+    label: "Logistics",
+    baseCost: { minerals: 140, energy: 35 },
+  },
+  automation: {
+    label: "Automation",
+    maxBonus: 0.5,
+    decay: 0.9,
+    baseCost: { minerals: 160, energy: 50, biomass: 30 },
+  },
+};
+
+export function roundCost(x) {
+  return Math.ceil(x / 5) * 5;
+}
+
+export function techDiscount(labLevel) {
+  const { techDiscountMax, techDiscountDecay } = constants;
+  return techDiscountMax * (1 - techDiscountDecay ** labLevel);
+}
+
+export function logisticsCostMult(rank, baseMult) {
+  return baseMult * (1 - 0.2 * (1 - 0.88 ** rank));
+}
+
+function scaleCostVector(base, scalar) {
+  const out = {};
+  for (const [k, v] of Object.entries(base)) {
+    out[k] = roundCost(v * scalar);
+  }
+  return out;
+}
+
+export function extractorBuildCost(planet, nPlaced, discount, logisticsRank) {
+  const baseMult = logisticsCostMult(logisticsRank, planet.costMult);
+  const scalar = constants.buildGrowth ** Math.max(0, nPlaced - 1) * baseMult * (1 - discount);
+  return scaleCostVector(baseBuild[planet.id], scalar);
+}
+
+export function extractorUpgradeCost(planet, level, discount, logisticsRank) {
+  const scalar = constants.extractorUpgradeGrowth ** Math.max(0, level - 1) * logisticsCostMult(logisticsRank, planet.costMult) * (1 - discount);
+  return scaleCostVector(baseUpgradeExtractor[planet.id], scalar);
+}
+
+export function powerUpgradeCost(planet, level, discount, logisticsRank) {
+  const scalar = constants.powerGrowth ** Math.max(0, level - 1) * logisticsCostMult(logisticsRank, planet.costMult) * (1 - discount);
+  return scaleCostVector(basePower[planet.id], scalar);
+}
+
+export function labUpgradeCost(planet, level, discount, logisticsRank) {
+  const scalar = constants.labGrowth ** Math.max(0, level - 1) * logisticsCostMult(logisticsRank, planet.costMult) * (1 - discount);
+  return scaleCostVector(baseLab[planet.id], scalar);
+}
+
+export function storageUpgradeCost(planet, level, discount, logisticsRank) {
+  const scalar = constants.storageGrowth ** Math.max(0, level - 1) * logisticsCostMult(logisticsRank, planet.costMult) * (1 - discount);
+  return scaleCostVector(baseStorage[planet.id], scalar);
+}
+
+export function techCost(techKey, rank, discount) {
+  const def = techDefs[techKey];
+  const scalar = constants.techGrowth ** Math.max(0, rank - 1) * (1 - discount);
+  return scaleCostVector(def.baseCost, scalar);
+}
+
+export function techMultipliers(techs) {
+  const extraction = 1 + techDefs.extraction.maxBonus * (1 - techDefs.extraction.decay ** techs.extraction);
+  const energy = 1 + 0.6 * (1 - 0.87 ** techs.energyOpt);
+  const automation = 1 + techDefs.automation.maxBonus * (1 - techDefs.automation.decay ** techs.automation);
+  return { extraction, energy, automation };
+}
+
+export function powerBonus(level, energyTechMult = 1) {
+  const base = constants.powerPmax * (1 - constants.powerDecay ** level);
+  return base * energyTechMult;
+}
+
+export function storageCap(level) {
+  return constants.baseCap * (1 + constants.capGain * level ** constants.capExp);
+}
+
+export function extractorRate({ planet, richness, level, powerMult, extractionTechMult, automationMult }) {
+  return planet.baseRate * richness * level ** constants.alpha * planet.yieldMult * powerMult * extractionTechMult * automationMult;
+}
+
+export function canUnlockPlanet(state, planetId) {
+  if (planetId === "ignis") {
+    return state.planets.terra.buildings.lab.level >= 2 && state.metrics.terraProd >= 6 && state.resources.minerals >= 1200;
+  }
+  if (planetId === "aqua") {
+    return state.tech.logistics >= 3 && unlockedPlanetCount(state) >= 2 && state.resources.minerals >= 1800 && state.resources.energy >= 600;
+  }
+  if (planetId === "zephyria") {
+    return unlockedPlanetCount(state) >= 3 && state.tech.extraction >= 6 && state.resources.minerals >= 2500 && state.resources.energy >= 900 && state.resources.biomass >= 700;
+  }
+  return false;
+}
+
+export function payUnlockCost(state, planetId) {
+  if (planetId === "ignis") {
+    state.resources.minerals -= 1200;
+  } else if (planetId === "aqua") {
+    state.resources.minerals -= 1800;
+    state.resources.energy -= 600;
+  } else if (planetId === "zephyria") {
+    state.resources.minerals -= 2500;
+    state.resources.energy -= 900;
+    state.resources.biomass -= 700;
+  }
+}
+
+export function unlockedPlanetCount(state) {
+  return planets.filter((p) => state.planets[p.id].unlocked).length;
+}
+
+export function clampResourceToCap(state) {
+  for (const key of Object.keys(state.resources)) {
+    state.resources[key] = clamp(state.resources[key], 0, state.caps[key]);
+  }
+}

--- a/modules/input.js
+++ b/modules/input.js
@@ -1,0 +1,102 @@
+import { clamp } from "./utils.js";
+import { tryPlaceBuilding } from "./sim.js";
+
+export function attachInput(canvas, state, renderer, refreshUI) {
+  const pointers = new Map();
+  let dragStart = null;
+
+  const updateGhost = (clientX, clientY) => {
+    const rect = canvas.getBoundingClientRect();
+    const { tx, ty } = renderer.screenToTile(clientX - rect.left, clientY - rect.top);
+    if (tx < 0 || ty < 0 || tx >= 48 || ty >= 32) return;
+    const attempt = tryPlaceBuildingPreview(state, tx, ty, state.ui.placeMode);
+    state.ui.ghostTile = { x: tx, y: ty, valid: attempt.ok };
+  };
+
+  canvas.addEventListener("pointerdown", (e) => {
+    canvas.setPointerCapture(e.pointerId);
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (pointers.size === 1) {
+      dragStart = { x: e.clientX, y: e.clientY, camX: state.camera.x, camY: state.camera.y };
+      updateGhost(e.clientX, e.clientY);
+    }
+  });
+
+  canvas.addEventListener("pointermove", (e) => {
+    if (!pointers.has(e.pointerId)) return;
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    if (pointers.size === 2) {
+      const [a, b] = [...pointers.values()];
+      if (!dragStart?.pinchDist) {
+        dragStart = { ...dragStart, pinchDist: Math.hypot(a.x - b.x, a.y - b.y), pinchZoom: state.camera.zoom };
+      }
+      const d = Math.hypot(a.x - b.x, a.y - b.y);
+      state.camera.zoom = clamp((dragStart.pinchZoom * d) / dragStart.pinchDist, 0.6, 2.5);
+      renderer.clampCamera();
+      return;
+    }
+
+    if (pointers.size === 1 && dragStart) {
+      const dx = e.clientX - dragStart.x;
+      const dy = e.clientY - dragStart.y;
+      state.camera.x = dragStart.camX + dx;
+      state.camera.y = dragStart.camY + dy;
+      renderer.clampCamera();
+      updateGhost(e.clientX, e.clientY);
+    }
+  });
+
+  canvas.addEventListener("pointerup", (e) => {
+    const hadOne = pointers.size === 1;
+    const point = pointers.get(e.pointerId);
+    pointers.delete(e.pointerId);
+
+    if (hadOne && dragStart && point) {
+      const moved = Math.hypot(point.x - dragStart.x, point.y - dragStart.y);
+      if (moved < 8 && state.ui.placeMode) {
+        const rect = canvas.getBoundingClientRect();
+        const { tx, ty } = renderer.screenToTile(e.clientX - rect.left, e.clientY - rect.top);
+        const placed = tryPlaceBuilding(state, state.activePlanetId, tx, ty, state.ui.placeMode);
+        if (!placed.ok) state.ui.invalidPulseUntil = performance.now() + 300;
+        else state.ui.message = `${state.ui.placeMode} placed`;
+        refreshUI();
+      }
+    }
+
+    if (pointers.size === 0) {
+      dragStart = null;
+      state.ui.ghostTile = null;
+    }
+  });
+
+  canvas.addEventListener("wheel", (e) => {
+    e.preventDefault();
+    const delta = -Math.sign(e.deltaY) * 0.1;
+    state.camera.zoom = clamp(state.camera.zoom + delta, 0.6, 2.5);
+    renderer.clampCamera();
+  }, { passive: false });
+
+  window.addEventListener("keydown", (e) => {
+    const step = 30;
+    if (["ArrowLeft", "a", "A"].includes(e.key)) state.camera.x += step;
+    if (["ArrowRight", "d", "D"].includes(e.key)) state.camera.x -= step;
+    if (["ArrowUp", "w", "W"].includes(e.key)) state.camera.y += step;
+    if (["ArrowDown", "s", "S"].includes(e.key)) state.camera.y -= step;
+    renderer.clampCamera();
+  });
+}
+
+function tryPlaceBuildingPreview(state, tx, ty, type) {
+  const pState = state.planets[state.activePlanetId];
+  const tile = pState.map.tiles[ty * 48 + tx];
+  if (!tile) return { ok: false };
+  const occupied = pState.buildings.extractors.some((b) => b.x === tx && b.y === ty) || ["power", "lab", "storage"].some((k) => {
+    const b = pState.buildings[k];
+    return b.placed && b.x === tx && b.y === ty;
+  });
+  if (occupied) return { ok: false };
+  if (type === "extractor") return { ok: tile.type === "node" };
+  if (type === "power" || type === "lab" || type === "storage") return { ok: tile.type === "empty" && !pState.buildings[type].placed };
+  return { ok: false };
+}

--- a/modules/mapgen.js
+++ b/modules/mapgen.js
@@ -1,0 +1,32 @@
+import { hashString, mulberry32 } from "./utils.js";
+
+export const MAP_W = 48;
+export const MAP_H = 32;
+
+export function tileIndex(x, y) {
+  return y * MAP_W + x;
+}
+
+export function generatePlanetMap(planetId, seedStr) {
+  const seed = hashString(`${planetId}:${seedStr}`);
+  const rand = mulberry32(seed);
+  const tiles = new Array(MAP_W * MAP_H);
+  const nodeType = planetId;
+
+  for (let y = 0; y < MAP_H; y++) {
+    for (let x = 0; x < MAP_W; x++) {
+      const edgeDist = Math.min(x, y, MAP_W - 1 - x, MAP_H - 1 - y);
+      const edgePenalty = edgeDist < 2 ? 0.15 : 0;
+      const r = rand();
+      let type = "empty";
+      if (r < 0.11 + edgePenalty) type = "obstacle";
+      else if (r < 0.2) type = "node";
+      tiles[tileIndex(x, y)] = {
+        type,
+        nodeType: type === "node" ? nodeType : null,
+        richness: type === "node" ? 0.8 + rand() * 0.4 : 0,
+      };
+    }
+  }
+  return { width: MAP_W, height: MAP_H, tiles };
+}

--- a/modules/renderer.js
+++ b/modules/renderer.js
@@ -1,0 +1,161 @@
+import { planets } from "./balance.js";
+import { MAP_H, MAP_W, tileIndex } from "./mapgen.js";
+
+const TILE = 40;
+const DPR_MAX = 2;
+
+function drawNodeIcon(ctx, type, x, y, color) {
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.fillStyle = color;
+  ctx.shadowColor = color;
+  ctx.shadowBlur = 6;
+  ctx.beginPath();
+  if (type === "terra") {
+    ctx.moveTo(0, -6); ctx.lineTo(6, 0); ctx.lineTo(0, 6); ctx.lineTo(-6, 0);
+  } else if (type === "ignis") {
+    ctx.moveTo(-4, 5); ctx.lineTo(0, -7); ctx.lineTo(4, 5);
+  } else if (type === "aqua") {
+    ctx.arc(0, 0, 5, 0, Math.PI * 2);
+  } else {
+    ctx.arc(0, 0, 5, 0, Math.PI * 1.5);
+  }
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+export class Renderer {
+  constructor(canvas, state) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext("2d");
+    this.state = state;
+    this.dpr = 1;
+    this.bgCache = {};
+    this.resize();
+  }
+
+  resize() {
+    const rect = this.canvas.getBoundingClientRect();
+    this.dpr = Math.min(DPR_MAX, window.devicePixelRatio || 1);
+    this.canvas.width = Math.floor(rect.width * this.dpr);
+    this.canvas.height = Math.floor(rect.height * this.dpr);
+    this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+  }
+
+  getPlanetDef() {
+    return planets.find((p) => p.id === this.state.activePlanetId);
+  }
+
+  ensureBg(planetId) {
+    if (this.bgCache[planetId]) return;
+    const off = document.createElement("canvas");
+    off.width = MAP_W * TILE;
+    off.height = MAP_H * TILE;
+    const c = off.getContext("2d");
+    const def = planets.find((p) => p.id === planetId);
+    const g = c.createLinearGradient(0, 0, off.width, off.height);
+    g.addColorStop(0, def.bg);
+    g.addColorStop(1, "#0a1025");
+    c.fillStyle = g;
+    c.fillRect(0, 0, off.width, off.height);
+    c.globalAlpha = 0.08;
+    for (let i = 0; i < 2000; i++) {
+      c.fillStyle = i % 2 ? "#fff" : def.accent;
+      c.fillRect(Math.random() * off.width, Math.random() * off.height, 1, 1);
+    }
+    this.bgCache[planetId] = off;
+  }
+
+  draw() {
+    const { ctx, state } = this;
+    const pState = state.planets[state.activePlanetId];
+    this.ensureBg(state.activePlanetId);
+
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    ctx.save();
+    const z = state.camera.zoom;
+    ctx.translate(state.camera.x, state.camera.y);
+    ctx.scale(z, z);
+
+    ctx.drawImage(this.bgCache[state.activePlanetId], 0, 0);
+
+    for (let y = 0; y < MAP_H; y++) {
+      for (let x = 0; x < MAP_W; x++) {
+        const tile = pState.map.tiles[tileIndex(x, y)];
+        const px = x * TILE;
+        const py = y * TILE;
+        ctx.strokeStyle = "rgba(255,255,255,0.08)";
+        ctx.strokeRect(px, py, TILE, TILE);
+        if (tile.type === "obstacle") {
+          ctx.fillStyle = "rgba(255,255,255,0.1)";
+          ctx.fillRect(px + 6, py + 6, TILE - 12, TILE - 12);
+        } else if (tile.type === "node") {
+          const alpha = 0.18 + (tile.richness - 0.8) * 0.6;
+          ctx.fillStyle = `rgba(255,255,255,${alpha.toFixed(2)})`;
+          ctx.fillRect(px + 8, py + 8, TILE - 16, TILE - 16);
+          drawNodeIcon(ctx, pState.map.tiles[tileIndex(x, y)].nodeType, px + TILE / 2, py + TILE / 2, this.getPlanetDef().accent);
+        }
+      }
+    }
+
+    const drawBuilding = (x, y, lvl, color, shape = "rect") => {
+      const px = x * TILE + 6;
+      const py = y * TILE + 6;
+      ctx.fillStyle = color;
+      if (shape === "tri") {
+        ctx.beginPath();
+        ctx.moveTo(px + TILE / 2 - 6, py + 4);
+        ctx.lineTo(px + 6, py + TILE - 12);
+        ctx.lineTo(px + TILE - 18, py + TILE - 12);
+        ctx.closePath();
+        ctx.fill();
+      } else if (shape === "circle") {
+        ctx.beginPath();
+        ctx.arc(px + TILE / 2 - 6, py + TILE / 2 - 6, 10, 0, Math.PI * 2);
+        ctx.fill();
+      } else {
+        ctx.fillRect(px, py, TILE - 12, TILE - 12);
+      }
+      ctx.fillStyle = "#fff";
+      ctx.font = "10px sans-serif";
+      ctx.fillText(`L${lvl}`, px + 2, py + 12);
+    };
+
+    for (const ext of pState.buildings.extractors) drawBuilding(ext.x, ext.y, ext.level, "#82f6ff");
+    if (pState.buildings.power.placed) drawBuilding(pState.buildings.power.x, pState.buildings.power.y, pState.buildings.power.level, "#ffc07a", "tri");
+    if (pState.buildings.lab.placed) drawBuilding(pState.buildings.lab.x, pState.buildings.lab.y, pState.buildings.lab.level, "#dca0ff", "circle");
+    if (pState.buildings.storage.placed) drawBuilding(pState.buildings.storage.x, pState.buildings.storage.y, pState.buildings.storage.level, "#95ffa8");
+
+    if (state.ui.ghostTile && state.ui.placeMode) {
+      const { x, y, valid } = state.ui.ghostTile;
+      ctx.strokeStyle = valid ? "#33ff88" : "#ff4f4f";
+      ctx.lineWidth = 3;
+      if (!valid && performance.now() < state.ui.invalidPulseUntil) {
+        const shake = Math.sin(performance.now() * 0.05) * 3;
+        ctx.strokeRect(x * TILE + shake, y * TILE + shake, TILE, TILE);
+      } else {
+        ctx.strokeRect(x * TILE, y * TILE, TILE, TILE);
+      }
+    }
+
+    ctx.restore();
+  }
+
+  screenToTile(screenX, screenY) {
+    const x = (screenX - this.state.camera.x) / this.state.camera.zoom;
+    const y = (screenY - this.state.camera.y) / this.state.camera.zoom;
+    return { tx: Math.floor(x / TILE), ty: Math.floor(y / TILE) };
+  }
+
+  clampCamera() {
+    const viewW = this.canvas.clientWidth;
+    const viewH = this.canvas.clientHeight;
+    const worldW = MAP_W * TILE * this.state.camera.zoom;
+    const worldH = MAP_H * TILE * this.state.camera.zoom;
+    const minX = Math.min(0, viewW - worldW);
+    const minY = Math.min(0, viewH - worldH);
+    this.state.camera.x = Math.min(0, Math.max(minX, this.state.camera.x));
+    this.state.camera.y = Math.min(0, Math.max(minY, this.state.camera.y));
+  }
+}

--- a/modules/save.js
+++ b/modules/save.js
@@ -1,0 +1,75 @@
+import { createNewState, SAVE_VERSION } from "./state.js";
+import { generatePlanetMap } from "./mapgen.js";
+
+const KEY = "planetary_dominion_save";
+
+export function saveGame(state) {
+  const payload = {
+    version: SAVE_VERSION,
+    lastSeen: Date.now(),
+    activePlanetId: state.activePlanetId,
+    resources: state.resources,
+    caps: state.caps,
+    tech: state.tech,
+    settings: state.settings,
+    planets: Object.fromEntries(
+      Object.entries(state.planets).map(([id, p]) => [
+        id,
+        {
+          unlocked: p.unlocked,
+          seed: p.seed,
+          buildings: p.buildings,
+        },
+      ])
+    ),
+  };
+  localStorage.setItem(KEY, JSON.stringify(payload));
+}
+
+export function loadGame() {
+  const raw = localStorage.getItem(KEY);
+  if (!raw) return createNewState();
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed.version !== SAVE_VERSION) throw new Error("version mismatch");
+
+    const state = createNewState();
+    state.lastSeen = parsed.lastSeen || Date.now();
+    state.activePlanetId = parsed.activePlanetId || "terra";
+    state.resources = { ...state.resources, ...(parsed.resources || {}) };
+    state.caps = { ...state.caps, ...(parsed.caps || {}) };
+    state.tech = { ...state.tech, ...(parsed.tech || {}) };
+    state.settings = { ...state.settings, ...(parsed.settings || {}) };
+
+    for (const [id, p] of Object.entries(parsed.planets || {})) {
+      if (!state.planets[id]) continue;
+      state.planets[id].unlocked = !!p.unlocked;
+      state.planets[id].seed = p.seed || state.planets[id].seed;
+      state.planets[id].map = generatePlanetMap(id, state.planets[id].seed);
+      state.planets[id].buildings = p.buildings || state.planets[id].buildings;
+    }
+    return state;
+  } catch {
+    return createNewState();
+  }
+}
+
+export function exportSave(state) {
+  const data = localStorage.getItem(KEY);
+  return data || JSON.stringify(state);
+}
+
+export function importSave(text) {
+  try {
+    const parsed = JSON.parse(text);
+    if (typeof parsed !== "object") throw new Error("invalid");
+    localStorage.setItem(KEY, JSON.stringify(parsed));
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Invalid JSON save" };
+  }
+}
+
+export function clearSave() {
+  localStorage.removeItem(KEY);
+}

--- a/modules/sim.js
+++ b/modules/sim.js
@@ -1,0 +1,173 @@
+import {
+  planets,
+  techDiscount,
+  techMultipliers,
+  powerBonus,
+  storageCap,
+  extractorRate,
+  extractorBuildCost,
+  extractorUpgradeCost,
+  powerUpgradeCost,
+  labUpgradeCost,
+  storageUpgradeCost,
+  techCost,
+  canUnlockPlanet,
+  payUnlockCost,
+  clampResourceToCap,
+} from "./balance.js";
+import { tileIndex } from "./mapgen.js";
+import { RES_KEYS } from "./utils.js";
+
+export function getPlanet(state, planetId = state.activePlanetId) {
+  return planets.find((p) => p.id === planetId);
+}
+
+export function recalcCaps(state) {
+  const base = { minerals: 1000, energy: 1000, biomass: 1000, rareGas: 1000 };
+  for (const planet of planets) {
+    const pState = state.planets[planet.id];
+    base[planet.resource] = storageCap(pState.buildings.storage.level);
+  }
+  state.caps = base;
+  clampResourceToCap(state);
+}
+
+export function getResourcePerSecond(state) {
+  const rates = { minerals: 0, energy: 0, biomass: 0, rareGas: 0 };
+  const techMults = techMultipliers(state.tech);
+
+  for (const planet of planets) {
+    const pState = state.planets[planet.id];
+    if (!pState.unlocked) continue;
+
+    const powerLvl = pState.buildings.power.level;
+    const powerMult = 1 + powerBonus(powerLvl, techMults.energy);
+
+    for (const ext of pState.buildings.extractors) {
+      const tile = pState.map.tiles[tileIndex(ext.x, ext.y)];
+      if (!tile || tile.type !== "node") continue;
+      rates[planet.resource] += extractorRate({
+        planet,
+        richness: tile.richness,
+        level: ext.level,
+        powerMult,
+        extractionTechMult: techMults.extraction,
+        automationMult: techMults.automation,
+      });
+    }
+  }
+
+  state.metrics.terraProd = rates.minerals;
+  state.metrics.totalProdByRes = rates;
+  return rates;
+}
+
+export function tick(state, dtSec) {
+  const rates = getResourcePerSecond(state);
+  for (const r of RES_KEYS) {
+    state.resources[r] = Math.min(state.caps[r], state.resources[r] + rates[r] * dtSec);
+  }
+}
+
+export function applyOfflineProgress(state) {
+  const now = Date.now();
+  const dt = Math.min(12 * 3600, Math.max(0, (now - state.lastSeen) / 1000));
+  if (dt > 0) tick(state, dt);
+  state.lastSeen = now;
+  return dt;
+}
+
+function canAfford(state, cost) {
+  return Object.entries(cost).every(([k, v]) => (state.resources[k] || 0) >= v);
+}
+
+function spend(state, cost) {
+  for (const [k, v] of Object.entries(cost)) state.resources[k] -= v;
+}
+
+export function tryPlaceBuilding(state, planetId, x, y, type) {
+  const planet = getPlanet(state, planetId);
+  const pState = state.planets[planetId];
+  const tile = pState.map.tiles[tileIndex(x, y)];
+  if (!tile) return { ok: false, reason: "out" };
+
+  if (pState.buildings.extractors.some((b) => b.x === x && b.y === y)) return { ok: false, reason: "occupied" };
+  for (const t of ["power", "lab", "storage"]) {
+    const b = pState.buildings[t];
+    if (b.placed && b.x === x && b.y === y) return { ok: false, reason: "occupied" };
+  }
+
+  const discount = techDiscount(pState.buildings.lab.level);
+  const logistics = state.tech.logistics;
+  if (type === "extractor") {
+    if (tile.type !== "node") return { ok: false, reason: "needsNode" };
+    const cost = extractorBuildCost(planet, pState.buildings.extractors.length + 1, discount, logistics);
+    if (!canAfford(state, cost)) return { ok: false, reason: "cost", cost };
+    spend(state, cost);
+    pState.buildings.extractors.push({ x, y, level: 1 });
+    return { ok: true, cost };
+  }
+
+  if (tile.type !== "empty") return { ok: false, reason: "needsEmpty" };
+  const slot = pState.buildings[type];
+  if (!slot || slot.placed) return { ok: false, reason: "exists" };
+
+  const level = 1;
+  const costByType = {
+    power: powerUpgradeCost,
+    lab: labUpgradeCost,
+    storage: storageUpgradeCost,
+  };
+  const cost = costByType[type](planet, level, discount, logistics);
+  if (!canAfford(state, cost)) return { ok: false, reason: "cost", cost };
+  spend(state, cost);
+  pState.buildings[type] = { placed: true, x, y, level };
+  recalcCaps(state);
+  return { ok: true, cost };
+}
+
+export function tryUpgrade(state, planetId, type, idx = -1) {
+  const pState = state.planets[planetId];
+  const planet = getPlanet(state, planetId);
+  const discount = techDiscount(pState.buildings.lab.level);
+  const logistics = state.tech.logistics;
+
+  if (type === "extractor") {
+    const ext = pState.buildings.extractors[idx];
+    if (!ext || ext.level >= 10) return { ok: false };
+    const cost = extractorUpgradeCost(planet, ext.level, discount, logistics);
+    if (!canAfford(state, cost)) return { ok: false, cost };
+    spend(state, cost);
+    ext.level += 1;
+    return { ok: true, cost };
+  }
+
+  const b = pState.buildings[type];
+  if (!b.placed || b.level >= 10) return { ok: false };
+  const fns = { power: powerUpgradeCost, lab: labUpgradeCost, storage: storageUpgradeCost };
+  const cost = fns[type](planet, b.level + 1, discount, logistics);
+  if (!canAfford(state, cost)) return { ok: false, cost };
+  spend(state, cost);
+  b.level += 1;
+  if (type === "storage") recalcCaps(state);
+  return { ok: true, cost };
+}
+
+export function tryBuyTech(state, key) {
+  const rank = state.tech[key];
+  if (rank >= 10) return { ok: false };
+  const terraLab = state.planets.terra.buildings.lab.level;
+  const cost = techCost(key, rank + 1, techDiscount(terraLab));
+  if (!canAfford(state, cost)) return { ok: false, cost };
+  spend(state, cost);
+  state.tech[key] += 1;
+  return { ok: true, cost };
+}
+
+export function tryUnlock(state, planetId) {
+  if (state.planets[planetId].unlocked) return { ok: false };
+  if (!canUnlockPlanet(state, planetId)) return { ok: false };
+  payUnlockCost(state, planetId);
+  state.planets[planetId].unlocked = true;
+  return { ok: true };
+}

--- a/modules/state.js
+++ b/modules/state.js
@@ -1,0 +1,57 @@
+import { planets, storageCap } from "./balance.js";
+import { generatePlanetMap } from "./mapgen.js";
+
+export const SAVE_VERSION = 1;
+
+function planetTemplate(planet) {
+  return {
+    unlocked: planet.id === "terra",
+    seed: `${planet.id}-001`,
+    map: generatePlanetMap(planet.id, `${planet.id}-001`),
+    buildings: {
+      extractors: [],
+      power: { placed: false, x: -1, y: -1, level: 0 },
+      lab: { placed: false, x: -1, y: -1, level: 0 },
+      storage: { placed: false, x: -1, y: -1, level: 0 },
+    },
+  };
+}
+
+export function createNewState() {
+  const state = {
+    version: SAVE_VERSION,
+    lastSeen: Date.now(),
+    activePlanetId: "terra",
+    resources: { minerals: 500, energy: 0, biomass: 0, rareGas: 0 },
+    caps: { minerals: storageCap(0), energy: storageCap(0), biomass: storageCap(0), rareGas: storageCap(0) },
+    tech: { extraction: 0, energyOpt: 0, logistics: 0, automation: 0 },
+    settings: {
+      reducedMotion: window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false,
+    },
+    ui: {
+      currentTab: "planet",
+      placeMode: null,
+      ghostTile: null,
+      selectedTile: null,
+      message: "Welcome Commander",
+      invalidPulseUntil: 0,
+      resourcePulse: 0,
+    },
+    metrics: {
+      terraProd: 0,
+      totalProdByRes: { minerals: 0, energy: 0, biomass: 0, rareGas: 0 },
+    },
+    planets: {},
+    camera: {
+      x: 0,
+      y: 0,
+      zoom: 1,
+    },
+  };
+
+  for (const planet of planets) {
+    state.planets[planet.id] = planetTemplate(planet);
+  }
+
+  return state;
+}

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -1,0 +1,141 @@
+import { planets, techDefs, techDiscount, techCost } from "./balance.js";
+import { formatNum } from "./utils.js";
+import { getResourcePerSecond, tryBuyTech, tryUnlock, tryUpgrade } from "./sim.js";
+import { exportSave, importSave, clearSave } from "./save.js";
+
+export function setupUI(state, onStateChanged) {
+  const resBar = document.querySelector("#resourceBar");
+  const tabs = document.querySelector("#tabs");
+  const panel = document.querySelector("#panel");
+
+  tabs.addEventListener("click", (e) => {
+    const btn = e.target.closest("button[data-tab]");
+    if (!btn) return;
+    state.ui.currentTab = btn.dataset.tab;
+    render();
+  });
+
+  panel.addEventListener("click", (e) => {
+    const action = e.target.closest("[data-action]");
+    if (!action) return;
+    const planetId = state.activePlanetId;
+    if (action.dataset.action === "set-planet") {
+      state.activePlanetId = action.dataset.id;
+      onStateChanged();
+    } else if (action.dataset.action === "unlock") {
+      tryUnlock(state, action.dataset.id);
+      onStateChanged();
+    } else if (action.dataset.action === "place") {
+      state.ui.placeMode = action.dataset.type;
+      onStateChanged();
+    } else if (action.dataset.action === "cancel-place") {
+      state.ui.placeMode = null;
+      onStateChanged();
+    } else if (action.dataset.action === "upg") {
+      tryUpgrade(state, planetId, action.dataset.type, Number(action.dataset.idx));
+      onStateChanged();
+    } else if (action.dataset.action === "buy-tech") {
+      tryBuyTech(state, action.dataset.tech);
+      onStateChanged();
+    } else if (action.dataset.action === "toggle-reduced") {
+      state.settings.reducedMotion = !state.settings.reducedMotion;
+      document.body.classList.toggle("reduce-motion", state.settings.reducedMotion);
+      onStateChanged();
+    } else if (action.dataset.action === "export") {
+      panel.querySelector("#saveText").value = exportSave(state);
+    } else if (action.dataset.action === "import") {
+      const val = panel.querySelector("#saveText").value;
+      const res = importSave(val);
+      state.ui.message = res.ok ? "Save imported. Reloading..." : res.error;
+      if (res.ok) location.reload();
+    } else if (action.dataset.action === "reset") {
+      clearSave();
+      location.reload();
+    }
+  });
+
+  function resLine(k, v, cap, perSec) {
+    return `<div class="res-item"><strong>${k}</strong><span>${formatNum(v)} / ${formatNum(cap)} (+${perSec.toFixed(2)}/s)</span></div>`;
+  }
+
+  function renderPlanetTab() {
+    const rates = getResourcePerSecond(state);
+    return `
+    <div class="cards">
+      ${planets
+        .map((p) => {
+          const unlocked = state.planets[p.id].unlocked;
+          const active = state.activePlanetId === p.id;
+          const button = unlocked
+            ? `<button data-action="set-planet" data-id="${p.id}">${active ? "Viewing" : "View"}</button>`
+            : `<button data-action="unlock" data-id="${p.id}">Unlock</button>`;
+          return `<article class="card ${active ? "active" : ""}">
+            <h3>${p.name}</h3>
+            <p>${unlocked ? `Production: ${rates[p.resource].toFixed(2)}/s` : "Locked"}</p>
+            ${button}
+          </article>`;
+        })
+        .join("")}
+    </div>`;
+  }
+
+  function renderBuildTab() {
+    const p = state.planets[state.activePlanetId].buildings;
+    const extractorRows = p.extractors
+      .map((e, i) => `<div class="row"><span>Extractor #${i + 1} L${e.level}</span><button data-action="upg" data-type="extractor" data-idx="${i}">Upgrade</button></div>`)
+      .join("");
+
+    return `<div>
+      <div class="row"><button data-action="place" data-type="extractor">Place Extractor</button></div>
+      <div class="row"><button data-action="place" data-type="power">Place Power Plant</button><button data-action="upg" data-type="power">Upgrade Power</button></div>
+      <div class="row"><button data-action="place" data-type="lab">Place Research Lab</button><button data-action="upg" data-type="lab">Upgrade Lab</button></div>
+      <div class="row"><button data-action="place" data-type="storage">Place Storage</button><button data-action="upg" data-type="storage">Upgrade Storage</button></div>
+      <div class="row"><button data-action="cancel-place">Cancel Placement</button></div>
+      <h4>Extractors</h4>
+      ${extractorRows || "<p>No extractors yet.</p>"}
+    </div>`;
+  }
+
+  function renderTechTab() {
+    const labLvl = state.planets.terra.buildings.lab.level;
+    const discount = techDiscount(labLvl);
+    return `<div>${Object.entries(techDefs)
+      .map(([k, v]) => {
+        const rank = state.tech[k];
+        const cost = techCost(k, rank + 1, discount);
+        const costText = Object.entries(cost)
+          .map(([rk, rv]) => `${rk[0].toUpperCase()}:${rv}`)
+          .join(" ");
+        return `<div class="tech-row"><div><strong>${v.label}</strong><p>Rank ${rank}/10</p></div><button data-action="buy-tech" data-tech="${k}">Buy (${costText})</button></div>`;
+      })
+      .join("")}</div>`;
+  }
+
+  function renderSettingsTab() {
+    return `<div>
+      <p>${state.ui.message}</p>
+      <div class="row"><button data-action="toggle-reduced">Reduced Motion: ${state.settings.reducedMotion ? "ON" : "OFF"}</button></div>
+      <textarea id="saveText" rows="6" placeholder="Exported save JSON"></textarea>
+      <div class="row"><button data-action="export">Export Save</button><button data-action="import">Import Save</button></div>
+      <div class="row"><button data-action="reset" class="danger">Reset Game</button></div>
+    </div>`;
+  }
+
+  function render() {
+    const rates = getResourcePerSecond(state);
+    resBar.innerHTML = [
+      resLine("Minerals", state.resources.minerals, state.caps.minerals, rates.minerals),
+      resLine("Energy", state.resources.energy, state.caps.energy, rates.energy),
+      resLine("Biomass", state.resources.biomass, state.caps.biomass, rates.biomass),
+      resLine("Rare Gas", state.resources.rareGas, state.caps.rareGas, rates.rareGas),
+    ].join("");
+
+    tabs.querySelectorAll("button").forEach((b) => b.classList.toggle("active", b.dataset.tab === state.ui.currentTab));
+    if (state.ui.currentTab === "planet") panel.innerHTML = renderPlanetTab();
+    if (state.ui.currentTab === "build") panel.innerHTML = renderBuildTab();
+    if (state.ui.currentTab === "tech") panel.innerHTML = renderTechTab();
+    if (state.ui.currentTab === "settings") panel.innerHTML = renderSettingsTab();
+  }
+
+  return { render };
+}

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,0 +1,43 @@
+export const RES_KEYS = ["minerals", "energy", "biomass", "rareGas"];
+
+export function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+export function formatNum(value) {
+  if (value >= 1e9) return `${(value / 1e9).toFixed(2)}B`;
+  if (value >= 1e6) return `${(value / 1e6).toFixed(2)}M`;
+  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
+  return value.toFixed(value >= 100 ? 0 : 1);
+}
+
+export function deepClone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+export function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function rand() {
+    t += 0x6d2b79f5;
+    let x = Math.imul(t ^ (t >>> 15), 1 | t);
+    x ^= x + Math.imul(x ^ (x >>> 7), 61 | x);
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function hashString(str) {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+export function nowMs() {
+  return Date.now();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,96 @@
+:root {
+  --bg: #0a1021;
+  --panel: rgba(8, 12, 24, 0.88);
+  --text: #eff4ff;
+  --muted: #9fb1d5;
+  --border: rgba(255,255,255,0.15);
+}
+* { box-sizing: border-box; }
+html, body {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+#app {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+}
+#canvasWrap {
+  position: absolute;
+  inset: 0;
+  touch-action: none;
+}
+#gameCanvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+#overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+#resourceBar {
+  position: absolute;
+  top: max(8px, env(safe-area-inset-top));
+  left: 8px;
+  right: 8px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 8px;
+  backdrop-filter: blur(4px);
+  pointer-events: auto;
+}
+.res-item { display: flex; justify-content: space-between; font-size: 12px; padding: 2px 0; }
+#panel {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(68px + env(safe-area-inset-bottom));
+  max-height: 44vh;
+  overflow: auto;
+  background: var(--panel);
+  border-top: 1px solid var(--border);
+  padding: 12px;
+  pointer-events: auto;
+}
+#tabs {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: calc(64px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  background: rgba(9,14,30,0.95);
+  border-top: 1px solid var(--border);
+  pointer-events: auto;
+}
+#tabs button, button {
+  min-height: 44px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #1c2749;
+  color: var(--text);
+  padding: 8px 10px;
+}
+#tabs button {
+  border-radius: 0;
+  border: 0;
+}
+#tabs button.active { background: #33467d; }
+.cards { display: grid; gap: 8px; }
+.card { border: 1px solid var(--border); border-radius: 12px; padding: 10px; }
+.card.active { border-color: #52d6f9; }
+.row { display: flex; gap: 8px; margin-bottom: 8px; }
+.row > * { flex: 1; }
+.tech-row { display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 10px; }
+textarea { width: 100%; background: #081127; color: #dce8ff; border: 1px solid var(--border); border-radius: 10px; padding: 8px; }
+.danger { background: #6c1d2f; }
+.reduce-motion * { animation: none !important; transition: none !important; }


### PR DESCRIPTION
### Motivation
- Build a polished, mobile-first (iPhone Safari compatible) 2D tile-map colony/idle game using only vanilla HTML/CSS/ESM with no build step.
- Provide deterministic multi-planet maps, resource extraction, upgrades, tech progression and planet unlock flow driven by exact formulas for a balanced economy.
- Ensure good mobile performance and UX with Canvas rendering, pointer events (pan/pinch), safe-area handling, offline progress and robust save/import/export.

### Description
- Add a complete app scaffold (`index.html`, `styles.css`) and modular game code under `modules/`: `balance.js`, `state.js`, `sim.js`, `save.js`, `mapgen.js`, `renderer.js`, `input.js`, `ui.js`, and `utils.js` implementing the full game systems and UI.
- Implement exact economy/constants in `modules/balance.js` including extractor formulas, `alpha`, `powerBonus`, storage cap growth, cost growth curves, tech discounts and unlock requirements/costs.
- Implement simulation and progression in `modules/sim.js` with a fixed-step tick loop, offline accumulation (capped at 12 hours), placement/upgrade validation, tech purchases and cap clamping.
- Implement performant Canvas rendering and input handling in `modules/renderer.js` and `modules/input.js` with DPR clamping, offscreen background cache, ghost placement preview, invalid-placement pulse, pinch zoom/pan, wheel zoom and keyboard pan; implement DOM overlay UI (tabs/panels) and save/import/export in `modules/ui.js` and `modules/save.js`.

### Testing
- Ran a module syntax check with `node --check modules/*.js` which completed successfully.
- Served the build with `python3 -m http.server 8000` and performed a smoke load (headless Playwright screenshot) to verify the app boots in-browser, which succeeded.
- Verified autosave (`saveGame` every 10s), `loadGame` recovers from corrupted saves by falling back to `createNewState`, and offline progress applies up to the 12h cap during startup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69995520bc788330b434e4bec180d9b8)