### PR TITLE
Balance early-game expansion: tune starting resources and planet unlock costs

### DIFF
--- a/modules/state.js
+++ b/modules/state.js
@@ -5,6 +5,13 @@ import { PLANET_TEMPLATES, RESOURCES } from "./content.js";
 /** @returns {import('./types').GameState|any} */
 export function createInitialState() {
   const now = Date.now();
+  const unlockCostsByIndex = [
+    { ore: 0, water: 0, bio: 0, energy: 0 },
+    { ore: 85, water: 0, bio: 0, energy: 0 },
+    { ore: 130, water: 45, bio: 0, energy: 0 },
+    { ore: 180, water: 70, bio: 35, energy: 0 },
+    { ore: 240, water: 90, bio: 55, energy: 40 },
+  ];
   const planets = PLANET_TEMPLATES.map((tpl, i) => ({
     id: `planet-${i}`,
     name: `${tpl.type[0].toUpperCase()}${tpl.type.slice(1)}-${i + 1}`,
@@ -12,17 +19,17 @@ export function createInitialState() {
     distance: 160 + i * 90,
     angle: (Math.PI * 2 * i) / PLANET_TEMPLATES.length,
     unlocked: i === 0,
-    unlockCost: { ore: 35 + i * 50, water: i * 20, bio: i * 15, energy: i * 10 },
+    unlockCost: unlockCostsByIndex[i],
     extractorLevel: 1,
     extractorSlots: 1 + Math.floor(i / 2),
     buffer: Object.fromEntries(Object.keys(RESOURCES).map(r => [r, 0])),
   }));
 
   return {
-    version: 1,
+    version: 2,
     time: now,
     lastSaveAt: now,
-    resources: { ore: 80, water: 40, bio: 20, energy: 20 },
+    resources: { ore: 90, water: 30, bio: 20, energy: 20 },
     rates: { ore: 0, water: 0, bio: 0, energy: 0 },
     storageCap: { ore: 500, water: 500, bio: 500, energy: 500 },
     mothership: { x: 0, y: 0 },


### PR DESCRIPTION
### Motivation
- The initial starting stockpile and linear planet unlock formula made early expansion unreliable and could lead to stall states, so the early progression curve needed retuning.
- The goal was to make the first expansion step reachable without removing longer-term progression gates.

### Description
- Introduced a tuned per-planet unlock cost table `unlockCostsByIndex` and applied it to each planet's `unlockCost` instead of the previous linear formula. 
- Increased the initial `ore` and reduced `water` in the starting `resources` to better support opening actions (`resources: { ore: 90, water: 30, bio: 20, energy: 20 }`).
- Bumped the initial save `version` to `2` so fresh runs use the updated balance profile.

### Testing
- Ran syntax/type checks with `node --check modules/state.js`, `node --check modules/sim.js`, and `node --check modules/ui.js`, and they completed without errors. 
- Verified the modified file `modules/state.js` loads cleanly in the codebase via the same checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d0e65d608330847b8d0d9d69d5f7)