### PR TITLE
Fix ship orientation along bezier travel paths

### DIFF
--- a/modules/render.js
+++ b/modules/render.js
@@ -93,6 +93,8 @@ function drawShip(state, ctx, s) {
   const control = { x: (a.x + b.x) / 2 + (b.y - a.y) * 0.18, y: (a.y + b.y) / 2 - (b.x - a.x) * 0.18 };
   const t = (s.state === "TRAVEL_TO_PLANET" || s.state === "TRAVEL_TO_MOTHERSHIP") ? s.progress : (rev ? 1 : 0);
   const pos = bezier(a, control, b, t);
+  const heading = bezierTangent(a, control, b, t);
+  const angle = Math.atan2(heading.y, heading.x);
 
   ctx.strokeStyle = "rgba(120,160,210,.2)";
   ctx.beginPath();
@@ -102,6 +104,7 @@ function drawShip(state, ctx, s) {
 
   ctx.save();
   ctx.translate(pos.x, pos.y);
+  ctx.rotate(angle);
   ctx.fillStyle = "#d4e8ff";
   ctx.beginPath();
   ctx.moveTo(8, 0); ctx.lineTo(-7, 5); ctx.lineTo(-4, 0); ctx.lineTo(-7, -5);
@@ -141,6 +144,13 @@ function bezier(a, c, b, t) {
   return {
     x: mt * mt * a.x + 2 * mt * t * c.x + t * t * b.x,
     y: mt * mt * a.y + 2 * mt * t * c.y + t * t * b.y,
+  };
+}
+
+function bezierTangent(a, c, b, t) {
+  return {
+    x: 2 * (1 - t) * (c.x - a.x) + 2 * t * (b.x - c.x),
+    y: 2 * (1 - t) * (c.y - a.y) + 2 * t * (b.y - c.y),
   };
 }
 


### PR DESCRIPTION
### Motivation
- Ships appeared to fly backward when returning from planets to the mothership because their sprites did not rotate to match curve direction.
- The rendering should orient ships to face the direction of travel along the bezier route for visually correct motion.

### Description
- Rotate ship sprites to match the bezier path tangent by computing a heading vector and angle before drawing (uses `Math.atan2`).
- Added a reusable `bezierTangent(a, c, b, t)` helper that returns the derivative vector along the quadratic bezier curve.
- Apply `ctx.rotate(angle)` after translating to the ship position so the ship graphic faces its direction of motion.

### Testing
- Ran `node --check modules/render.js` and it completed successfully.
- Launched the app with `python3 -m http.server 4173` and verified rendering loaded successfully in a browser container.
- Executed a Playwright-based visual check that captured a screenshot of the updated rendering and confirmed ship orientation was corrected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d05703608330beebd1e5ae23632c)