### PR TITLE
Expand progression to 20 planets with colonies, industries and new resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,21 @@ A no-build 2D planet resource-gathering game built with Canvas 2D and ES modules
 2. Optional: serve locally for cleaner module loading behavior (`python3 -m http.server`).
 
 ## Gameplay loop
-- Planets continuously produce resources into local buffers.
+- Planets continuously produce mixed resource profiles into local buffers.
 - Ships cycle through: `TRAVEL_TO_PLANET -> LOADING -> TRAVEL_TO_MOTHERSHIP -> UNLOADING`.
-- Spend resources to unlock planets, buy ships, upgrade extractors, and research tech.
+- Expand to new planets to unlock new resource types, establish colonies, and develop industries.
+- Colony industries generate Science, which unlocks advanced technologies.
 
 ## Controls
 - **Desktop**: drag to pan, mouse wheel to zoom, click ships/planets to inspect.
 - **Mobile**: drag to pan, pinch to zoom, tap to select; bottom tabs switch Actions/Details/Tech.
 
 ## Features
-- 4 resources: Ore, Water, Bio, Energy.
-- Distinct planet types with richness/distance differences.
+- 10 resources with progressive unlocks (Ore, Water, Bio, Energy, Silicon, Crystals, Reactive Gas, Alloys, Antimatter, Science).
+- 20-planet star system with distinct planet archetypes and scalable unlock costs.
+- Colony system with industry development (Mining, Refining, Biolab, Fusion Plant, Research Nexus).
+- Expanded technology tree that depends on colony-driven Science generation.
 - Curved ship paths + thruster trail + cargo indicator + floating unload text.
-- 9 tech upgrades with prerequisites and immediate effects.
 - Fixed-step simulation (10 ticks/s) + smooth render loop.
 - Save/load in `localStorage`, offline progress capped to 8 hours.
 - Reset save from DevTools: `resetSave()`.

--- a/game.js
+++ b/game.js
@@ -1,4 +1,4 @@
-import { createInitialState } from "./modules/state.js";
+import { createInitialState, normalizeState } from "./modules/state.js";
 import { tick } from "./modules/sim.js";
 import { render, hitTest } from "./modules/render.js";
 import { bindUI, drawPanels, drawTopBar } from "./modules/ui.js";
@@ -14,8 +14,10 @@ const refs = {
   mobileSheet: document.getElementById("mobileSheet"),
 };
 
-const state = loadGame() || createInitialState();
-if (loadGame()) applyOfflineProgress(state);
+const saved = loadGame();
+const state = saved || createInitialState();
+normalizeState(state);
+if (saved) applyOfflineProgress(state);
 window.resetSave = () => { resetSave(); location.reload(); };
 
 bindUI(state, refs);

--- a/modules/content.js
+++ b/modules/content.js
@@ -1,26 +1,45 @@
 export const RESOURCES = {
-  ore: { name: "Ore", color: "#b0b7c3" },
-  water: { name: "Water", color: "#63d7ff" },
-  bio: { name: "Bio", color: "#7def8a" },
-  energy: { name: "Energy", color: "#ffd46a" },
+  ore: { name: "Ore", color: "#b0b7c3", unlockPlanet: 0 },
+  water: { name: "Water", color: "#63d7ff", unlockPlanet: 0 },
+  bio: { name: "Bio", color: "#7def8a", unlockPlanet: 0 },
+  energy: { name: "Energy", color: "#ffd46a", unlockPlanet: 0 },
+  silicon: { name: "Silicon", color: "#d7d1ff", unlockPlanet: 2 },
+  crystal: { name: "Crystals", color: "#9ffff3", unlockPlanet: 4 },
+  gas: { name: "Reactive Gas", color: "#c4a8ff", unlockPlanet: 6 },
+  alloy: { name: "Alloys", color: "#9fa7b8", unlockPlanet: 8 },
+  antimatter: { name: "Antimatter", color: "#ff7bc1", unlockPlanet: 11 },
+  science: { name: "Science", color: "#fffd8f", unlockPlanet: 1 },
 };
 
 export const PLANET_TEMPLATES = [
-  { type: "rocky", primaryResource: "ore", richness: 1.2, color: "#7f6f65" },
-  { type: "ice", primaryResource: "water", richness: 1.15, color: "#9ad9ff" },
-  { type: "lush", primaryResource: "bio", richness: 1.25, color: "#4cc77f" },
-  { type: "volcanic", primaryResource: "energy", richness: 1.35, color: "#d86140" },
-  { type: "gas", primaryResource: "energy", richness: 1.1, color: "#c8b3ff" },
+  { type: "rocky", richness: 1.05, color: "#7f6f65", affinities: ["ore", "silicon", "alloy"] },
+  { type: "ice", richness: 1.0, color: "#9ad9ff", affinities: ["water", "crystal"] },
+  { type: "lush", richness: 1.1, color: "#4cc77f", affinities: ["bio", "water", "science"] },
+  { type: "volcanic", richness: 1.2, color: "#d86140", affinities: ["energy", "ore", "gas"] },
+  { type: "gas", richness: 1.15, color: "#c8b3ff", affinities: ["gas", "energy", "antimatter"] },
+  { type: "crystalline", richness: 1.25, color: "#7cf0e8", affinities: ["crystal", "silicon", "science"] },
+  { type: "metallic", richness: 1.3, color: "#9aa0b2", affinities: ["alloy", "ore", "energy"] },
+  { type: "rift", richness: 1.35, color: "#8b69ff", affinities: ["antimatter", "gas", "science"] },
 ];
+
+export const INDUSTRIES = {
+  mining: { name: "Mining Complex", desc: "+14% planetary extraction", baseCost: { ore: 35, energy: 20 } },
+  refining: { name: "Refinery", desc: "+10% extraction and unlocks Alloy conversion", baseCost: { ore: 40, silicon: 15, energy: 20 } },
+  biotech: { name: "Biolab", desc: "Boosts Bio + Science output", baseCost: { water: 35, bio: 35, crystal: 12 } },
+  power: { name: "Fusion Plant", desc: "Improves all industry efficiency", baseCost: { ore: 40, gas: 20, energy: 35 } },
+  research: { name: "Research Nexus", desc: "Generates Science for advanced tech", baseCost: { crystal: 30, silicon: 25, energy: 30 } },
+};
 
 export const UPGRADES = [
   { id: "thrusters1", name: "Improved Thrusters", desc: "+15% ship speed", cost: { ore: 40, energy: 20 }, prereq: [], effect: s => s.modifiers.shipSpeed *= 1.15 },
   { id: "cargo1", name: "Expanded Cargo Holds", desc: "+8 capacity", cost: { ore: 60, bio: 20 }, prereq: [], effect: s => s.modifiers.shipCapacity += 8 },
   { id: "dock1", name: "Auto-Docking", desc: "-20% load/unload time", cost: { energy: 45, water: 30 }, prereq: [], effect: s => s.modifiers.dockTime *= 0.8 },
-  { id: "extractor2", name: "Extractor MK2", desc: "+25% planet output", cost: { ore: 80, water: 40 }, prereq: ["thrusters1"], effect: s => s.modifiers.extractorOutput *= 1.25 },
-  { id: "storage1", name: "Storage Expansion I", desc: "+300 to all caps", cost: { ore: 80, bio: 40 }, prereq: ["cargo1"], effect: s => Object.keys(s.storageCap).forEach(k => s.storageCap[k] += 300) },
-  { id: "routeAI", name: "Route AI", desc: "Auto assign idle ships to best ROI", cost: { energy: 120, bio: 80 }, prereq: ["dock1"], effect: s => s.modifiers.routeAI = true },
-  { id: "refine", name: "Advanced Refining", desc: "Ore grants +15% Energy on unload", cost: { ore: 120, energy: 100 }, prereq: ["extractor2"], effect: s => s.modifiers.refining = 0.15 },
-  { id: "thrusters2", name: "Thrusters Mk3", desc: "+20% ship speed", cost: { ore: 180, energy: 140 }, prereq: ["thrusters1"], effect: s => s.modifiers.shipSpeed *= 1.2 },
-  { id: "storage2", name: "Storage Expansion II", desc: "+500 to all caps", cost: { ore: 220, water: 120, bio: 120 }, prereq: ["storage1"], effect: s => Object.keys(s.storageCap).forEach(k => s.storageCap[k] += 500) },
+  { id: "extractor2", name: "Extractor MK2", desc: "+25% planet output", cost: { ore: 80, water: 40, science: 18 }, prereq: ["thrusters1"], effect: s => s.modifiers.extractorOutput *= 1.25 },
+  { id: "storage1", name: "Storage Expansion I", desc: "+300 to all caps", cost: { ore: 80, bio: 40, silicon: 20 }, prereq: ["cargo1"], effect: s => Object.keys(s.storageCap).forEach(k => s.storageCap[k] += 300) },
+  { id: "routeAI", name: "Route AI", desc: "Auto assign idle ships to best ROI", cost: { energy: 120, bio: 80, science: 60 }, prereq: ["dock1"], effect: s => s.modifiers.routeAI = true },
+  { id: "refine", name: "Advanced Refining", desc: "Ore unload grants +20% Energy", cost: { ore: 120, energy: 100, alloy: 40 }, prereq: ["extractor2"], effect: s => s.modifiers.refining = 0.2 },
+  { id: "thrusters2", name: "Thrusters Mk3", desc: "+20% ship speed", cost: { ore: 180, energy: 140, gas: 60 }, prereq: ["thrusters1"], effect: s => s.modifiers.shipSpeed *= 1.2 },
+  { id: "storage2", name: "Storage Expansion II", desc: "+550 to all caps", cost: { ore: 220, water: 120, bio: 120, alloy: 80 }, prereq: ["storage1"], effect: s => Object.keys(s.storageCap).forEach(k => s.storageCap[k] += 550) },
+  { id: "quantumLogistics", name: "Quantum Logistics", desc: "Ships gain +12 capacity and +15% speed", cost: { science: 180, crystal: 120, antimatter: 50 }, prereq: ["thrusters2", "routeAI"], effect: s => { s.modifiers.shipCapacity += 12; s.modifiers.shipSpeed *= 1.15; } },
+  { id: "colonyNet", name: "Colony Hypernet", desc: "Colony industries +25% effectiveness", cost: { science: 220, silicon: 140, gas: 90 }, prereq: ["storage2"], effect: s => s.modifiers.colonyBonus *= 1.25 },
 ];

--- a/modules/state.js
+++ b/modules/state.js
@@ -1,48 +1,111 @@
-import { PLANET_TEMPLATES, RESOURCES } from "./content.js";
+import { INDUSTRIES, PLANET_TEMPLATES, RESOURCES } from "./content.js";
 
-/** @typedef {{x:number,y:number}} Vec2 */
+const RESOURCE_IDS = Object.keys(RESOURCES);
+const PLANET_LIMIT = 20;
+
+function resourceMap(initial = 0) {
+  return Object.fromEntries(RESOURCE_IDS.map(id => [id, initial]));
+}
+
+function resourcesUnlockedByPlanet(index) {
+  return RESOURCE_IDS.filter(id => RESOURCES[id].unlockPlanet <= index);
+}
+
+function unlockCostForPlanet(index) {
+  if (index === 0) return resourceMap(0);
+  const known = resourcesUnlockedByPlanet(index - 1);
+  const base = 60 + index * 28;
+  const cost = resourceMap(0);
+  known.forEach((id, i) => {
+    const rarity = 1 + i * 0.42;
+    cost[id] = Math.floor((base * rarity) / Math.max(1.15, known.length * 0.45));
+  });
+  return cost;
+}
+
+function makeResourceProfile(template, index) {
+  const unlocked = resourcesUnlockedByPlanet(index);
+  const weighted = [];
+  template.affinities.forEach((id, i) => {
+    if (unlocked.includes(id)) weighted.push({ id, weight: Math.max(0.2, 0.62 - i * 0.16) });
+  });
+  if (!weighted.length) weighted.push({ id: unlocked[0], weight: 1 });
+
+  const extras = unlocked.filter(id => !weighted.some(w => w.id === id));
+  if (extras.length && index > 0) {
+    const seed = (index * 7) % extras.length;
+    weighted.push({ id: extras[seed], weight: 0.22 + (index % 3) * 0.05 });
+  }
+
+  const total = weighted.reduce((sum, x) => sum + x.weight, 0);
+  return weighted.map(x => ({ id: x.id, share: x.weight / total }));
+}
+
+function createPlanet(index) {
+  const tpl = PLANET_TEMPLATES[index % PLANET_TEMPLATES.length];
+  return {
+    id: `planet-${index}`,
+    name: `${tpl.type[0].toUpperCase()}${tpl.type.slice(1)}-${index + 1}`,
+    ...tpl,
+    resourceProfile: makeResourceProfile(tpl, index),
+    distance: 150 + index * 52,
+    angle: (Math.PI * 2 * index) / PLANET_LIMIT,
+    unlocked: index === 0,
+    unlockCost: unlockCostForPlanet(index),
+    extractorLevel: 1,
+    extractorSlots: 1 + Math.floor(index / 3),
+    buffer: resourceMap(0),
+    colony: { established: false, population: 0, industries: Object.fromEntries(Object.keys(INDUSTRIES).map(k => [k, 0])) },
+  };
+}
 
 /** @returns {import('./types').GameState|any} */
 export function createInitialState() {
   const now = Date.now();
-  const unlockCostsByIndex = [
-    { ore: 0, water: 0, bio: 0, energy: 0 },
-    { ore: 85, water: 0, bio: 0, energy: 0 },
-    { ore: 130, water: 45, bio: 0, energy: 0 },
-    { ore: 180, water: 70, bio: 35, energy: 0 },
-    { ore: 240, water: 90, bio: 55, energy: 40 },
-  ];
-  const planets = PLANET_TEMPLATES.map((tpl, i) => ({
-    id: `planet-${i}`,
-    name: `${tpl.type[0].toUpperCase()}${tpl.type.slice(1)}-${i + 1}`,
-    ...tpl,
-    distance: 160 + i * 90,
-    angle: (Math.PI * 2 * i) / PLANET_TEMPLATES.length,
-    unlocked: i === 0,
-    unlockCost: unlockCostsByIndex[i],
-    extractorLevel: 1,
-    extractorSlots: 1 + Math.floor(i / 2),
-    buffer: Object.fromEntries(Object.keys(RESOURCES).map(r => [r, 0])),
-  }));
+  const planets = Array.from({ length: PLANET_LIMIT }, (_, i) => createPlanet(i));
 
   return {
-    version: 2,
+    version: 3,
     time: now,
     lastSaveAt: now,
-    resources: { ore: 90, water: 30, bio: 20, energy: 20 },
-    rates: { ore: 0, water: 0, bio: 0, energy: 0 },
-    storageCap: { ore: 500, water: 500, bio: 500, energy: 500 },
+    resources: { ...resourceMap(0), ore: 110, water: 40, bio: 30, energy: 30 },
+    rates: resourceMap(0),
+    storageCap: resourceMap(650),
     mothership: { x: 0, y: 0 },
     planets,
     ships: [makeShip(0)],
     nextShipId: 1,
     selected: { kind: "mothership", id: "mothership" },
-    modifiers: { shipSpeed: 1, shipCapacity: 0, dockTime: 1, extractorOutput: 1, routeAI: false, refining: 0 },
+    modifiers: { shipSpeed: 1, shipCapacity: 0, dockTime: 1, extractorOutput: 1, routeAI: false, refining: 0, colonyBonus: 1 },
     unlockedUpgrades: [],
     camera: { x: 0, y: 0, zoom: 1 },
     fx: { floaters: [], twinkleSeed: Math.random() * 9999 },
     mobileTab: "actions",
   };
+}
+
+export function normalizeState(state) {
+  const fresh = createInitialState();
+  state.version = fresh.version;
+  state.resources = { ...fresh.resources, ...(state.resources || {}) };
+  state.rates = { ...fresh.rates, ...(state.rates || {}) };
+  state.storageCap = { ...fresh.storageCap, ...(state.storageCap || {}) };
+  state.modifiers = { ...fresh.modifiers, ...(state.modifiers || {}) };
+  state.planets = (state.planets || []).slice(0, PLANET_LIMIT);
+
+  while (state.planets.length < PLANET_LIMIT) state.planets.push(createPlanet(state.planets.length));
+
+  state.planets.forEach((p, i) => {
+    const baseline = createPlanet(i);
+    p.resourceProfile = p.resourceProfile || baseline.resourceProfile;
+    p.buffer = { ...resourceMap(0), ...(p.buffer || {}) };
+    p.unlockCost = p.unlockCost || baseline.unlockCost;
+    p.colony = p.colony || baseline.colony;
+    p.colony.population = p.colony.population || 0;
+    p.colony.industries = { ...baseline.colony.industries, ...(p.colony.industries || {}) };
+  });
+
+  state.ships.forEach(s => { s.cargo = { ...resourceMap(0), ...(s.cargo || {}) }; });
 }
 
 export function makeShip(idx) {
@@ -52,7 +115,7 @@ export function makeShip(idx) {
     state: "TRAVEL_TO_PLANET",
     progress: 0,
     dockTimer: 0,
-    cargo: { ore: 0, water: 0, bio: 0, energy: 0 },
+    cargo: resourceMap(0),
     capacity: 20,
     speed: 80,
   };

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -1,5 +1,5 @@
-import { RESOURCES, UPGRADES } from "./content.js";
-import { buyShip, unlockPlanet, upgradeExtractor, buyUpgrade, canAfford } from "./sim.js";
+import { INDUSTRIES, RESOURCES, UPGRADES } from "./content.js";
+import { buyShip, unlockPlanet, upgradeExtractor, buyUpgrade, canAfford, establishColony, upgradeIndustry } from "./sim.js";
 
 export function bindUI(state, refs) {
   refs.mobileTabs.addEventListener("click", (e) => {
@@ -23,6 +23,11 @@ function handleActionClick(state, refs, e) {
   if (action.startsWith("unlock:")) unlockPlanet(state, action.split(":")[1]);
   if (action.startsWith("extractor:")) upgradeExtractor(state, action.split(":")[1]);
   if (action.startsWith("tech:")) buyUpgrade(state, action.split(":")[1]);
+  if (action.startsWith("colony:")) establishColony(state, action.split(":")[1]);
+  if (action.startsWith("industry:")) {
+    const [, pid, iid] = action.split(":");
+    upgradeIndustry(state, pid, iid);
+  }
   if (action.startsWith("assign:")) {
     const pid = action.split(":")[1];
     const ship = state.ships.find(s => s.id === state.selected.id);
@@ -33,9 +38,9 @@ function handleActionClick(state, refs, e) {
 
 export function drawTopBar(state, topBar) {
   topBar.innerHTML = Object.entries(RESOURCES).map(([id, r]) => {
-    const cur = state.resources[id].toFixed(1);
-    const cap = state.storageCap[id].toFixed(0);
-    const rate = state.rates[id].toFixed(1);
+    const cur = (state.resources[id] || 0).toFixed(1);
+    const cap = (state.storageCap[id] || 0).toFixed(0);
+    const rate = (state.rates[id] || 0).toFixed(1);
     return `<div class="resourceChip"><span class="resourceDot" style="background:${r.color}"></span>${r.name}: ${cur}/${cap} <span class="meta">(+${rate}/s)</span></div>`;
   }).join("");
 }
@@ -49,7 +54,7 @@ export function drawPanels(state, refs) {
 function renderActions(state) {
   const unlocked = state.planets.filter(p => p.unlocked).length;
   const next = state.planets.find(p => !p.unlocked);
-  const shipCost = { ore: 60 + state.ships.length * 35, energy: 20 + state.ships.length * 12 };
+  const shipCost = { ore: 60 + state.ships.length * 35, energy: 20 + state.ships.length * 12, alloy: state.ships.length > 2 ? 14 + state.ships.length * 3 : 0 };
   return `<h3>Actions</h3>
     <div class="card">Ships: ${state.ships.length}
       <button data-action="buyShip" ${canAfford(state, shipCost) ? "" : "disabled"}>Buy Ship (${fmtCost(shipCost)})</button>
@@ -76,24 +81,40 @@ function renderTech(state) {
 function renderDetails(state) {
   if (state.selected.kind === "planet") {
     const p = state.planets.find(x => x.id === state.selected.id);
-    const cost = { ore: 25 * p.extractorLevel, bio: 10 * p.extractorLevel };
+    const cost = { ore: 25 * p.extractorLevel, bio: 10 * p.extractorLevel, silicon: Math.max(0, 8 * (p.extractorLevel - 1)) };
+    const colonyCost = { ore: 80 + p.distance * 0.12, water: 35, energy: 40, bio: 30 };
     return `<h3>${p.name}</h3>
-      <div class="card">Type: ${p.type}<br/>Primary: ${p.primaryResource}<br/>Richness: x${p.richness}<br/>Distance: ${p.distance}
+      <div class="card">Type: ${p.type}<br/>Richness: x${p.richness}<br/>Distance: ${p.distance}
+      <div class="meta">Resource Mix: ${p.resourceProfile.map(x => `${RESOURCES[x.id].name} ${(x.share * 100).toFixed(0)}%`).join(", ")}</div>
       <div class="meta">Extractor Lv.${p.extractorLevel} (slots ${p.extractorSlots})</div>
-      <div class="meta">Buffer: ${p.buffer[p.primaryResource].toFixed(1)}</div>
-      <button data-action="extractor:${p.id}" ${canAfford(state, cost) ? "" : "disabled"}>Upgrade Extractor (${fmtCost(cost)})</button></div>`;
+      <div class="meta">Buffer: ${p.resourceProfile.map(x => `${RESOURCES[x.id].name} ${(p.buffer[x.id] || 0).toFixed(1)}`).join(", ")}</div>
+      <button data-action="extractor:${p.id}" ${canAfford(state, cost) ? "" : "disabled"}>Upgrade Extractor (${fmtCost(cost)})</button></div>
+      <div class="card"><strong>Colony</strong><br/>${p.colony.established ? `Population: ${Math.floor(p.colony.population)}` : "No colony established"}
+        ${p.colony.established ? renderIndustryButtons(state, p) : `<button data-action="colony:${p.id}" ${canAfford(state, colonyCost) ? "" : "disabled"}>Establish Colony (${fmtCost(colonyCost)})</button>`}
+      </div>`;
   }
   if (state.selected.kind === "ship") {
     const s = state.ships.find(x => x.id === state.selected.id);
     return `<h3>${s.id}</h3><div class="card">State: ${s.state}<br/>Route: Mothership ↔ ${s.planetId}<br/>ETA: ${(1 - s.progress).toFixed(2)}
-      <div class="meta">Cargo: ${Object.entries(s.cargo).filter(([,v]) => v>0.05).map(([k,v]) => `${k}:${v.toFixed(1)}`).join(", ") || "Empty"}</div>
+      <div class="meta">Cargo: ${Object.entries(s.cargo).filter(([, v]) => v > 0.05).map(([k, v]) => `${k}:${v.toFixed(1)}`).join(", ") || "Empty"}</div>
       ${state.planets.filter(p => p.unlocked).map(p => `<button data-action="assign:${p.id}">Assign ${p.name}</button>`).join("")}
     </div>`;
   }
   return `<h3>Mothership</h3><div class="card">Hub operational.<br/>Fleet: ${state.ships.length}<br/>Upgrades: ${state.unlockedUpgrades.length}
+    <div class="meta">Colonies: ${state.planets.filter(p => p.colony.established).length}</div></div>`;
+}
+
+function renderIndustryButtons(state, p) {
+  return Object.entries(INDUSTRIES).map(([id, info]) => {
+    const lv = p.colony.industries[id] || 0;
+    const scalar = 1 + lv * 0.85;
+    const cost = Object.fromEntries(Object.entries(info.baseCost).map(([k, v]) => [k, Math.floor(v * scalar)]));
+    return `<div class="meta">${info.name} Lv.${lv} — ${info.desc}
+      <button data-action="industry:${p.id}:${id}" ${canAfford(state, cost) ? "" : "disabled"}>Develop (${fmtCost(cost)})</button>
     </div>`;
+  }).join("");
 }
 
 function fmtCost(cost) {
-  return Object.entries(cost).filter(([, v]) => v > 0).map(([k, v]) => `${v} ${k}`).join(", ");
+  return Object.entries(cost).filter(([, v]) => v > 0).map(([k, v]) => `${Math.floor(v)} ${k}`).join(", ");
 }


### PR DESCRIPTION
### Motivation
- Solve progression bottleneck by making each planet produce mixed resource types and unlocking new resources as you expand. 
- Add deeper gameplay (colonies & industries) so planets can be developed to boost output and generate research (Science). 
- Increase planetary system size to 20 and make unlock costs and resource mixes scale with expansion. 
- Keep older saves compatible by normalizing missing fields at load.

### Description
- Added new resources and metadata in `modules/content.js` (10 resources with `unlockPlanet` thresholds), new planet archetypes with `affinities`, an `INDUSTRIES` table, and expanded `UPGRADES` to consume new resources and science. 
- Reworked `modules/state.js` to support `PLANET_LIMIT = 20`, `resourceMap`, per-planet `resourceProfile`, generated `unlockCostForPlanet`, `createPlanet`, expanded initial state, and `normalizeState` to auto-fill/migrate older saves. 
- Updated `modules/sim.js` so planets produce multiple resources from their profile, added `industryMultiplier` and `produceColonyScience`, prioritized multi-resource loading for ships, added `establishColony` and `upgradeIndustry` actions, and adjusted costs (e.g. alloy). 
- Extended UI (`modules/ui.js`) to show all resources robustly, render per-planet resource mixes and buffers, add colony/industry controls and costs, and update tech/action panels to reflect new resources and upgrades. 
- Modified `game.js` to normalize loaded saves (`normalizeState`) before applying offline progress, and updated `README.md` to describe the new progression loop.

### Testing
- Ran static syntax checks: `node --check game.js && node --check modules/content.js && node --check modules/state.js && node --check modules/sim.js && node --check modules/ui.js && node --check modules/render.js`, which completed successfully. 
- Launched a local server (`python3 -m http.server 4173`) and used an automated Playwright script to load the UI and capture a screenshot, which completed and produced an artifact. 
- All automated checks above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3d17747083309d71da35984287c8)