### PR TITLE
Ensure planets have multiple resources and grant ship on unlock

### DIFF
--- a/modules/sim.js
+++ b/modules/sim.js
@@ -112,20 +112,14 @@ export function payCost(state, cost) {
   return true;
 }
 
-export function buyShip(state) {
-  const cost = { ore: 60 + state.ships.length * 35, energy: 20 + state.ships.length * 12, alloy: state.ships.length > 2 ? 14 + state.ships.length * 3 : 0 };
-  if (!payCost(state, cost)) return false;
-  const ship = makeShip(state.nextShipId++);
-  const unlocked = state.planets.filter(p => p.unlocked);
-  ship.planetId = unlocked[state.ships.length % unlocked.length].id;
-  state.ships.push(ship);
-  return true;
-}
-
 export function unlockPlanet(state, planetId) {
   const p = state.planets.find(x => x.id === planetId);
   if (!p || p.unlocked || !payCost(state, p.unlockCost)) return false;
   p.unlocked = true;
+
+  const ship = makeShip(state.nextShipId++);
+  ship.planetId = p.id;
+  state.ships.push(ship);
   return true;
 }
 

--- a/modules/state.js
+++ b/modules/state.js
@@ -32,9 +32,14 @@ function makeResourceProfile(template, index) {
   if (!weighted.length) weighted.push({ id: unlocked[0], weight: 1 });
 
   const extras = unlocked.filter(id => !weighted.some(w => w.id === id));
-  if (extras.length && index > 0) {
+  if (extras.length) {
     const seed = (index * 7) % extras.length;
     weighted.push({ id: extras[seed], weight: 0.22 + (index % 3) * 0.05 });
+  }
+
+  if (weighted.length < 2 && unlocked.length >= 2) {
+    const fallback = unlocked.find(id => !weighted.some(w => w.id === id));
+    if (fallback) weighted.push({ id: fallback, weight: 0.2 });
   }
 
   const total = weighted.reduce((sum, x) => sum + x.weight, 0);

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -1,5 +1,5 @@
 import { INDUSTRIES, RESOURCES, UPGRADES } from "./content.js";
-import { buyShip, unlockPlanet, upgradeExtractor, buyUpgrade, canAfford, establishColony, upgradeIndustry } from "./sim.js";
+import { unlockPlanet, upgradeExtractor, buyUpgrade, canAfford, establishColony, upgradeIndustry } from "./sim.js";
 
 export function bindUI(state, refs) {
   refs.mobileTabs.addEventListener("click", (e) => {
@@ -19,7 +19,6 @@ function handleActionClick(state, refs, e) {
   const b = e.target.closest("button[data-action]");
   if (!b) return;
   const action = b.dataset.action;
-  if (action === "buyShip") buyShip(state);
   if (action.startsWith("unlock:")) unlockPlanet(state, action.split(":")[1]);
   if (action.startsWith("extractor:")) upgradeExtractor(state, action.split(":")[1]);
   if (action.startsWith("tech:")) buyUpgrade(state, action.split(":")[1]);
@@ -54,11 +53,8 @@ export function drawPanels(state, refs) {
 function renderActions(state) {
   const unlocked = state.planets.filter(p => p.unlocked).length;
   const next = state.planets.find(p => !p.unlocked);
-  const shipCost = { ore: 60 + state.ships.length * 35, energy: 20 + state.ships.length * 12, alloy: state.ships.length > 2 ? 14 + state.ships.length * 3 : 0 };
   return `<h3>Actions</h3>
-    <div class="card">Ships: ${state.ships.length}
-      <button data-action="buyShip" ${canAfford(state, shipCost) ? "" : "disabled"}>Buy Ship (${fmtCost(shipCost)})</button>
-    </div>
+    <div class="card">Ships: ${state.ships.length}<div class="meta">Each newly unlocked planet grants 1 free ship.</div></div>
     <div class="card">Unlocked Planets: ${unlocked}/${state.planets.length}
       ${next ? `<button data-action="unlock:${next.id}" ${canAfford(state, next.unlockCost) ? "" : "disabled"}>Unlock ${next.name} (${fmtCost(next.unlockCost)})</button>` : "All planets unlocked"}
     </div>


### PR DESCRIPTION
### Motivation
- Guarantee each planet offers at least two resource types once two or more resources are globally unlocked so early planets are not single-resource.
- Automatically provide one free ship when a new planet is unlocked so unlocking always grants a ship rather than requiring a purchasable ship.
- Remove the manual ship-purchase action from the UI and replace it with explanatory fleet text to reflect the new unlock behaviour.

### Description
- Adjusted resource profile generation in `modules/state.js` to always include a second resource fallback when possible before normalizing shares. (`makeResourceProfile`) 
- Changed `unlockPlanet` in `modules/sim.js` to create and append a new ship assigned to the newly unlocked planet. 
- Removed the ship purchase action and cost from `modules/ui.js` and added explanatory text in the Actions panel stating each unlocked planet grants one free ship. 
- Kept all existing resource/industry/upgrades logic unchanged aside from the above behavior updates.

### Testing
- Ran syntax checks with `node --check modules/state.js modules/sim.js modules/ui.js` and they passed. 
- Executed a node script using `createInitialState()` to verify all generated planets have `resourceProfile.length >= 2` and it reported zero failing planets. 
- Executed a node script to fund a planet unlock and called `unlockPlanet(...)` to verify fleet size increments by one and the new ship is assigned to the unlocked planet, and it returned successful. 
- Started a local server and captured a headless UI screenshot via Playwright, saving `artifacts/ui-change.png`, to validate the Actions panel copy update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a53e3356c8330afb6f55cf84f4ea0)