### PR TITLE
Fix double loadGame call, throttle top bar renders, and cap offline progress

### DIFF
--- a/game.js
+++ b/game.js
@@ -14,8 +14,9 @@ const refs = {
   mobileSheet: document.getElementById("mobileSheet"),
 };
 
-const state = loadGame() || createInitialState();
-if (loadGame()) applyOfflineProgress(state);
+const saved = loadGame();
+const state = saved || createInitialState();
+if (saved) applyOfflineProgress(state);
 window.resetSave = () => { resetSave(); location.reload(); };
 
 bindUI(state, refs);

--- a/modules/storage.js
+++ b/modules/storage.js
@@ -23,6 +23,17 @@ export function resetSave() {
 export function applyOfflineProgress(state) {
   const elapsedMs = Date.now() - (state.lastSaveAt || Date.now());
   const capped = Math.min(elapsedMs, 8 * 3600_000);
-  const ticks = Math.floor(capped / 100);
-  for (let i = 0; i < ticks; i++) tick(state);
+  const totalTicks = Math.floor(capped / 100);
+  const SIM_LIMIT = 3000;
+  const ticksToRun = Math.min(totalTicks, SIM_LIMIT);
+  for (let i = 0; i < ticksToRun; i++) tick(state);
+  const remaining = totalTicks - ticksToRun;
+  if (remaining > 0) {
+    const dt = remaining * 0.1;
+    for (const p of state.planets) {
+      if (!p.unlocked) continue;
+      const output = 0.9 * p.richness * p.extractorLevel * p.extractorSlots * state.modifiers.extractorOutput * dt;
+      p.buffer[p.primaryResource] += output;
+    }
+  }
 }

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -31,13 +31,18 @@ function handleActionClick(state, refs, e) {
   drawPanels(state, refs);
 }
 
+let _lastTopBarHTML = "";
 export function drawTopBar(state, topBar) {
-  topBar.innerHTML = Object.entries(RESOURCES).map(([id, r]) => {
+  const html = Object.entries(RESOURCES).map(([id, r]) => {
     const cur = state.resources[id].toFixed(1);
     const cap = state.storageCap[id].toFixed(0);
     const rate = state.rates[id].toFixed(1);
     return `<div class="resourceChip"><span class="resourceDot" style="background:${r.color}"></span>${r.name}: ${cur}/${cap} <span class="meta">(+${rate}/s)</span></div>`;
   }).join("");
+  if (html !== _lastTopBarHTML) {
+    topBar.innerHTML = html;
+    _lastTopBarHTML = html;
+  }
 }
 
 export function drawPanels(state, refs) {


### PR DESCRIPTION
- game.js: Store loadGame() result to avoid parsing localStorage JSON twice
- ui.js: Skip innerHTML rebuild when top bar content hasn't changed,
  avoiding redundant DOM writes on every animation frame
- storage.js: Cap simulated offline ticks at 3000 (5 min game time) to
  prevent browser freeze on long absences; approximate remaining time
  via bulk resource production instead

https://claude.ai/code/session_01MuCMydSw1HSRqLP7vXHYp2