### PR TITLE
Full-map visibility, mothership placement, and neutral trade stations

### DIFF
--- a/game.js
+++ b/game.js
@@ -90,8 +90,14 @@ function setupInput() {
     if (pointers.size < 2) lastDist = 0;
     if (!down?.moved) {
       const world = screenToWorld(e.clientX, e.clientY);
-      const target = hitTest(state, world.x, world.y);
-      if (target) state.selected = target;
+      if (state.placementMode) {
+        state.mothership.x = world.x;
+        state.mothership.y = world.y;
+        state.placementMode = false;
+      } else {
+        const target = hitTest(state, world.x, world.y);
+        if (target) state.selected = target;
+      }
     }
   });
 

--- a/modules/state.js
+++ b/modules/state.js
@@ -3,6 +3,14 @@ import { INDUSTRIES, PLANET_TEMPLATES, RESOURCES } from "./content.js";
 const RESOURCE_IDS = Object.keys(RESOURCES);
 const PLANET_LIMIT = 20;
 
+function makeStations() {
+  return [
+    { id: "station-0", name: "Drift Exchange", x: -360, y: 220, tradeRange: 170 },
+    { id: "station-1", name: "Helios Bazaar", x: 470, y: -180, tradeRange: 180 },
+    { id: "station-2", name: "Quiet Relay", x: 120, y: 430, tradeRange: 160 },
+  ];
+}
+
 function resourceMap(initial = 0) {
   return Object.fromEntries(RESOURCE_IDS.map(id => [id, initial]));
 }
@@ -65,14 +73,16 @@ export function createInitialState() {
   const planets = Array.from({ length: PLANET_LIMIT }, (_, i) => createPlanet(i));
 
   return {
-    version: 3,
+    version: 4,
     time: now,
     lastSaveAt: now,
     resources: { ...resourceMap(0), ore: 110, water: 40, bio: 30, energy: 30 },
     rates: resourceMap(0),
     storageCap: resourceMap(650),
-    mothership: { x: 0, y: 0 },
+    mothership: { x: 0, y: 0, commandRange: 460 },
+    placementMode: false,
     planets,
+    stations: makeStations(),
     ships: [makeShip(0)],
     nextShipId: 1,
     selected: { kind: "mothership", id: "mothership" },
@@ -91,6 +101,9 @@ export function normalizeState(state) {
   state.rates = { ...fresh.rates, ...(state.rates || {}) };
   state.storageCap = { ...fresh.storageCap, ...(state.storageCap || {}) };
   state.modifiers = { ...fresh.modifiers, ...(state.modifiers || {}) };
+  state.mothership = { ...fresh.mothership, ...(state.mothership || {}) };
+  state.placementMode = Boolean(state.placementMode);
+  state.stations = state.stations?.length ? state.stations : fresh.stations;
   state.planets = (state.planets || []).slice(0, PLANET_LIMIT);
 
   while (state.planets.length < PLANET_LIMIT) state.planets.push(createPlanet(state.planets.length));


### PR DESCRIPTION
### Motivation
- Players should see the entire 20-planet map from the start while still having progression gated by mothership positioning and range. 
- Allow the player to choose where to place the mothership so reachable planets/stations change dynamically. 
- Add neutral trading stations to introduce early trade opportunities and future gameplay hooks (contracts, reputation, escort, blueprints). 

### Description
- State changes: added `mothership` coordinates and `commandRange`, `placementMode`, `stations` list and bumped state `version` to `4`, and ensured normalization merges these fields (`modules/state.js`).
- Rendering/UI: render all 20 planets (locked planets are visually shaded), draw mothership at its coordinates and a dashed command-range ring, draw neutral stations with range rings and selection, and mark out-of-range planets with an outline (`modules/render.js`).
- Interaction: added a mothership placement mode toggled from the Actions panel so clicks can reposition the mothership, expanded hit-testing to include stations, and updated the panels to show reachability, station details, and trade buttons (`game.js`, `modules/ui.js`, `modules/render.js`).
- Simulation & rules: introduced `inCommandRange` checks that gate ship routes, `buyShip`, planet unlocks, and auto-assignment to only planets within command range, and implemented `tradeWithStation` with rotating give/get deals and a floater visual on success (`modules/sim.js`).

### Testing
- Ran static runtime checks with `node --check` on `game.js`, `modules/state.js`, `modules/render.js`, `modules/ui.js`, and `modules/sim.js`, all passing. 
- Performed a manual smoke test by serving the app with `python -m http.server` and captured a Playwright screenshot of the map to verify mothership placement, station rendering, and planet shading (screenshot artifact produced). 
- Verified the new behaviors in-browser: placement toggle moves the mothership, unreachable planets are shaded/outlined, stations are selectable and trades only execute when in range.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a55a8f03083309a9083e5dbdc6988)