### PR TITLE
Redesign mothership visuals and add purchasable mothership

### DIFF
--- a/modules/render.js
+++ b/modules/render.js
@@ -34,20 +34,60 @@ function planetPos(p) {
 
 function drawMothership(state, ctx) {
   ctx.save();
+
+  const hullGradient = ctx.createLinearGradient(-40, 0, 48, 0);
+  hullGradient.addColorStop(0, "#4a78af");
+  hullGradient.addColorStop(0.55, "#8fc4ff");
+  hullGradient.addColorStop(1, "#d8ecff");
+
+  ctx.fillStyle = hullGradient;
   ctx.beginPath();
-  ctx.fillStyle = "#9ec8ff";
-  ctx.arc(0, 0, 26, 0, Math.PI * 2);
+  ctx.moveTo(-44, 0);
+  ctx.quadraticCurveTo(-18, -20, 26, -14);
+  ctx.lineTo(52, 0);
+  ctx.lineTo(26, 14);
+  ctx.quadraticCurveTo(-18, 20, -44, 0);
+  ctx.closePath();
   ctx.fill();
-  ctx.strokeStyle = "#d5ecff";
-  ctx.lineWidth = 3;
+
+  ctx.fillStyle = "rgba(170, 214, 255, 0.9)";
+  ctx.beginPath();
+  ctx.ellipse(-4, -7, 12, 6, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = "#375a8c";
+  ctx.beginPath();
+  ctx.moveTo(-28, -12);
+  ctx.lineTo(-52, -22);
+  ctx.lineTo(-38, -4);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.moveTo(-28, 12);
+  ctx.lineTo(-52, 22);
+  ctx.lineTo(-38, 4);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = "rgba(100,213,255,.88)";
+  ctx.fillRect(-52, -5, 10, 10);
+
+  ctx.strokeStyle = "rgba(225, 241, 255, 0.85)";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(-30, 0);
+  ctx.lineTo(38, 0);
   ctx.stroke();
+
   if (state.selected.kind === "mothership") {
     ctx.strokeStyle = "rgba(100,213,255,0.8)";
     ctx.lineWidth = 2;
     ctx.beginPath();
-    ctx.arc(0, 0, 34, 0, Math.PI * 2);
+    ctx.ellipse(0, 0, 62, 32, 0, 0, Math.PI * 2);
     ctx.stroke();
   }
+
   ctx.restore();
 }
 
@@ -159,7 +199,7 @@ export function hitTest(state, worldX, worldY) {
     const pos = planetPos(p);
     if (Math.hypot(worldX - pos.x, worldY - pos.y) < 24) return { kind: "planet", id: p.id };
   }
-  if (Math.hypot(worldX, worldY) < 28) return { kind: "mothership", id: "mothership" };
+  if ((worldX * worldX) / (62 * 62) + (worldY * worldY) / (32 * 32) < 1) return { kind: "mothership", id: "mothership" };
   for (const s of state.ships) {
     const p = state.planets.find(x => x.id === s.planetId);
     const to = planetPos(p);

--- a/modules/sim.js
+++ b/modules/sim.js
@@ -122,6 +122,27 @@ export function buyShip(state) {
   return true;
 }
 
+export function mothershipCost(state) {
+  const owned = state.mothership.count;
+  return {
+    ore: 220 + owned * 140,
+    energy: 120 + owned * 80,
+    alloy: 45 + owned * 36,
+    crystal: owned > 1 ? 20 + owned * 16 : 0,
+  };
+}
+
+export function buyMothership(state) {
+  const cost = mothershipCost(state);
+  if (!payCost(state, cost)) return false;
+  state.mothership.count += 1;
+  state.mothership.tier += 1;
+  Object.keys(state.storageCap).forEach((id) => {
+    state.storageCap[id] += 220;
+  });
+  return true;
+}
+
 export function unlockPlanet(state, planetId) {
   const p = state.planets.find(x => x.id === planetId);
   if (!p || p.unlocked || !payCost(state, p.unlockCost)) return false;

--- a/modules/state.js
+++ b/modules/state.js
@@ -71,7 +71,7 @@ export function createInitialState() {
     resources: { ...resourceMap(0), ore: 110, water: 40, bio: 30, energy: 30 },
     rates: resourceMap(0),
     storageCap: resourceMap(650),
-    mothership: { x: 0, y: 0 },
+    mothership: { x: 0, y: 0, count: 1, tier: 1 },
     planets,
     ships: [makeShip(0)],
     nextShipId: 1,
@@ -91,6 +91,7 @@ export function normalizeState(state) {
   state.rates = { ...fresh.rates, ...(state.rates || {}) };
   state.storageCap = { ...fresh.storageCap, ...(state.storageCap || {}) };
   state.modifiers = { ...fresh.modifiers, ...(state.modifiers || {}) };
+  state.mothership = { ...fresh.mothership, ...(state.mothership || {}) };
   state.planets = (state.planets || []).slice(0, PLANET_LIMIT);
 
   while (state.planets.length < PLANET_LIMIT) state.planets.push(createPlanet(state.planets.length));

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -1,5 +1,5 @@
 import { INDUSTRIES, RESOURCES, UPGRADES } from "./content.js";
-import { buyShip, unlockPlanet, upgradeExtractor, buyUpgrade, canAfford, establishColony, upgradeIndustry } from "./sim.js";
+import { buyShip, unlockPlanet, upgradeExtractor, buyUpgrade, canAfford, establishColony, upgradeIndustry, buyMothership, mothershipCost } from "./sim.js";
 
 let clickAudioCtx;
 
@@ -49,6 +49,7 @@ function handleActionClick(state, refs, e) {
   playClickSound();
   const action = b.dataset.action;
   if (action === "buyShip") buyShip(state);
+  if (action === "buyMothership") buyMothership(state);
   if (action.startsWith("unlock:")) unlockPlanet(state, action.split(":")[1]);
   if (action.startsWith("extractor:")) upgradeExtractor(state, action.split(":")[1]);
   if (action.startsWith("tech:")) buyUpgrade(state, action.split(":")[1]);
@@ -84,9 +85,13 @@ function renderActions(state) {
   const unlocked = state.planets.filter(p => p.unlocked).length;
   const next = state.planets.find(p => !p.unlocked);
   const shipCost = { ore: 60 + state.ships.length * 35, energy: 20 + state.ships.length * 12, alloy: state.ships.length > 2 ? 14 + state.ships.length * 3 : 0 };
+  const nextMothershipCost = mothershipCost(state);
   return `<h3>Actions</h3>
     <div class="card">Ships: ${state.ships.length}
       <button data-action="buyShip" ${canAfford(state, shipCost) ? "" : "disabled"}>Buy Ship (${fmtCost(shipCost)})</button>
+    </div>
+    <div class="card">Motherships: ${state.mothership.count}
+      <button data-action="buyMothership" ${canAfford(state, nextMothershipCost) ? "" : "disabled"}>Buy Mothership (${fmtCost(nextMothershipCost)})</button>
     </div>
     <div class="card">Unlocked Planets: ${unlocked}/${state.planets.length}
       ${next ? `<button data-action="unlock:${next.id}" ${canAfford(state, next.unlockCost) ? "" : "disabled"}>Unlock ${next.name} (${fmtCost(next.unlockCost)})</button>` : "All planets unlocked"}
@@ -129,7 +134,8 @@ function renderDetails(state) {
       ${state.planets.filter(p => p.unlocked).map(p => `<button data-action="assign:${p.id}">Assign ${p.name}</button>`).join("")}
     </div>`;
   }
-  return `<h3>Mothership</h3><div class="card">Hub operational.<br/>Fleet: ${state.ships.length}<br/>Upgrades: ${state.unlockedUpgrades.length}
+  return `<h3>Mothership</h3><div class="card">Hub operational.<br/>Motherships: ${state.mothership.count}<br/>Fleet: ${state.ships.length}<br/>Upgrades: ${state.unlockedUpgrades.length}
+    <div class="meta">Hull Tier: ${state.mothership.tier}</div>
     <div class="meta">Colonies: ${state.planets.filter(p => p.colony.established).length}</div></div>`;
 }
 


### PR DESCRIPTION
### Motivation
- Make the mothership read as a large spaceship (not a planet) so it visually matches its role on the star map and enable progression by allowing players to purchase additional motherships.

### Description
- Replaced the circular mothership rendering with a stylized ship silhouette, added hull shading, cockpit/fin details, and a larger selection ring in `modules/render.js` and updated hit-testing to an ellipse to match the new footprint.
- Added purchasable mothership mechanics in `modules/sim.js` with `mothershipCost(state)` and `buyMothership(state)` that apply escalating costs and increase global storage capacity on purchase.
- Added persistent mothership progression fields (`mothership.count` and `mothership.tier`) to the initial state and save normalization in `modules/state.js` to preserve backward compatibility.
- Exposed the new action in the UI: wired `buyMothership` handling, added a `Buy Mothership` button to the Actions panel, and surfaced mothership count/tier in the Mothership details via `modules/ui.js`.

### Testing
- Ran static syntax checks with `node --check modules/sim.js && node --check modules/ui.js && node --check modules/render.js && node --check modules/state.js && node --check game.js`, which completed successfully.
- Attempted an automated browser screenshot of the running build using Playwright, but the headless screenshot step failed due to environment networking/path constraints (no visual artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5474a9b083308f4a037bc81888ba)