### PR TITLE
Rebalance early-game economy and expansion pacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ A no-build 2D planet resource-gathering game built with Canvas 2D and ES modules
 - Expand to new planets to unlock new resource types, establish colonies, and develop industries.
 - Colony industries generate Science, which unlocks advanced technologies.
 
+## Balance notes (current)
+- Starter planet now outputs a guaranteed mixed profile (Ore/Energy/Water/Bio), so the early game can fund ship growth and first expansion without soft-locking.
+- Early planet unlock costs are reduced and weighted toward accessible resources.
+- Early economy tuning: higher base extraction, slightly better starting stockpile, and stronger starter ships.
+- Cost formulas for ships/extractors/colonies are centralized in simulation logic to keep UI prices and gameplay prices consistent.
+
 ## Controls
 - **Desktop**: drag to pan, mouse wheel to zoom, click ships/planets to inspect.
 - **Mobile**: drag to pan, pinch to zoom, tap to select; bottom tabs switch Actions/Details/Tech.

--- a/modules/state.js
+++ b/modules/state.js
@@ -14,16 +14,31 @@ function resourcesUnlockedByPlanet(index) {
 function unlockCostForPlanet(index) {
   if (index === 0) return resourceMap(0);
   const known = resourcesUnlockedByPlanet(index - 1);
-  const base = 60 + index * 28;
+  const base = 36 + index * 20;
   const cost = resourceMap(0);
   known.forEach((id, i) => {
-    const rarity = 1 + i * 0.42;
-    cost[id] = Math.floor((base * rarity) / Math.max(1.15, known.length * 0.45));
+    const rarity = 1 + i * 0.3;
+    cost[id] = Math.floor((base * rarity) / Math.max(1.35, known.length * 0.6));
   });
+
+  if (index <= 3) {
+    cost.ore = Math.floor(cost.ore * 0.7);
+    cost.energy = Math.floor(cost.energy * 0.8);
+  }
+
   return cost;
 }
 
 function makeResourceProfile(template, index) {
+  if (index === 0) {
+    return [
+      { id: "ore", share: 0.45 },
+      { id: "energy", share: 0.25 },
+      { id: "water", share: 0.2 },
+      { id: "bio", share: 0.1 },
+    ];
+  }
+
   const unlocked = resourcesUnlockedByPlanet(index);
   const weighted = [];
   template.affinities.forEach((id, i) => {
@@ -32,9 +47,11 @@ function makeResourceProfile(template, index) {
   if (!weighted.length) weighted.push({ id: unlocked[0], weight: 1 });
 
   const extras = unlocked.filter(id => !weighted.some(w => w.id === id));
-  if (extras.length && index > 0) {
-    const seed = (index * 7) % extras.length;
-    weighted.push({ id: extras[seed], weight: 0.22 + (index % 3) * 0.05 });
+  const desiredChannels = index <= 3 ? 3 : 2;
+  while (extras.length && weighted.length < desiredChannels) {
+    const seed = (index * 7 + weighted.length) % extras.length;
+    const [picked] = extras.splice(seed, 1);
+    weighted.push({ id: picked, weight: 0.24 + (index % 3) * 0.05 });
   }
 
   const total = weighted.reduce((sum, x) => sum + x.weight, 0);
@@ -68,7 +85,7 @@ export function createInitialState() {
     version: 3,
     time: now,
     lastSaveAt: now,
-    resources: { ...resourceMap(0), ore: 110, water: 40, bio: 30, energy: 30 },
+    resources: { ...resourceMap(0), ore: 120, water: 60, bio: 45, energy: 55 },
     rates: resourceMap(0),
     storageCap: resourceMap(650),
     mothership: { x: 0, y: 0, count: 1, tier: 1 },
@@ -117,7 +134,7 @@ export function makeShip(idx) {
     progress: 0,
     dockTimer: 0,
     cargo: resourceMap(0),
-    capacity: 20,
-    speed: 80,
+    capacity: 24,
+    speed: 90,
   };
 }


### PR DESCRIPTION
### Motivation
- Prevent early-game soft-lock where the starter planet produced too little variety and players could not afford the next planet or ships. 
- Make first expansion reachable so players can realistically grow their fleet and access new resources. 
- Centralize and align cost formulas so displayed prices always match actual gameplay deductions for easier future tuning.

### Description
- Guarantee a mixed starter profile by changing `makeResourceProfile` so planet 0 yields a balanced `Ore/Energy/Water/Bio` mix. 
- Reduce early unlock pressure by lowering the unlock base and reweighting rarity in `unlockCostForPlanet` in `modules/state.js`. 
- Increase starting stockpile and slightly buff starter ship stats by updating `createInitialState` and `makeShip` in `modules/state.js`. 
- Boost base planetary extraction and add centralized cost helpers `shipCost`, `colonyCost`, and `extractorCost` in `modules/sim.js`, then use those helpers in purchase flows. 
- Update `modules/ui.js` to consume the shared cost functions (`shipCost`, `colonyCost`, `extractorCost`) so UI prices match simulation logic. 
- Add brief balance notes to `README.md` documenting the changes and rationale.

### Testing
- Ran a headless smoke simulation with `import {createInitialState} from './modules/state.js'; import {tick} from './modules/sim.js'` for 1200 ticks and verified starter planet profile and resource growth (showed non-zero `ore`, `water`, `bio`, `energy` after the run), which succeeded. 
- Performed static checks with `node --check` for `game.js`, `modules/state.js`, `modules/sim.js`, `modules/ui.js`, and `modules/content.js`, which reported no syntax issues. 
- Launched a local server and captured a Playwright screenshot of the running game to validate integration visually, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b173ca2a08330b68dddeb704c8f53)